### PR TITLE
optionnal drop posix compat and allow to handle long option name with one dash

### DIFF
--- a/src/cmdliner.ml
+++ b/src/cmdliner.ml
@@ -4,6 +4,12 @@
    %%NAME%% release %%VERSION%%
   ---------------------------------------------------------------------------*)
 
+let posix_compat = ref true
+let drop_posix_compat () = posix_compat := false
+let posix () = !posix_compat
+
+let dash n = if String.length n = 1 || not (posix ()) then "-" ^ n else "--" ^ n
+
 (* Invalid_arg strings *)
 
 let err_argv = "argv array must have at least one element"
@@ -589,11 +595,12 @@ module Err = struct
   let pr_try_help ppf ei = 
     let exec = Help.invocation ei in 
     let main = (fst ei.main).name in 
+    let help_opt = dash "help" in
     if exec = main then 
-      pr ppf "@[<2>Try `%s --help' for more information.@]" exec 
+      pr ppf "@[<2>Try `%s %s' for more information.@]" exec help_opt
     else
-    pr ppf "@[<2>Try `%s --help' or `%s --help' for more information.@]" 
-      exec main 
+    pr ppf "@[<2>Try `%s %s' or `%s %s' for more information.@]"
+      exec help_opt main help_opt
       
   let pr_usage ppf ei e =
     pr ppf "@[<v>%s: @[%a@]@,@[Usage: @[%a@]@]@,%a@]@."
@@ -653,13 +660,16 @@ end = struct
       
   let parse_opt_arg s =          (* (name,value) of opt arg, assert len > 1. *)
     let l = String.length s in
-    if s.[1] <> '-' then
-      if l = 2 then s, None else
-      String.sub s 0 2, Some (String.sub s 2 (l - 2))
-    else try 
+    let doubledash = s.[1] = '-' in
+    if l = 2 && not doubledash
+    then s, None
+    else if doubledash || not (posix ())
+    then try
       let i = String.index s '=' in 
       String.sub s 0 i, Some (String.sub s (i + 1) (l - i - 1))
     with Not_found -> s, None
+    else
+      String.sub s 0 2, Some (String.sub s 2 (l - 2))
                       
   let parse_args opti cl args =
     (* returns an updated [cl] cmdline according to the options found in [args]
@@ -747,7 +757,6 @@ module Arg = struct
     (fun ppf v -> match v with None -> pr_str ppf none| Some v -> print ppf v)
     
   let info ?docs ?(docv = "") ?(doc = "") names = 
-    let dash n = if String.length n = 1 then "-" ^ n else "--" ^ n in
     let docs = match docs with 
     | None -> if names = [] then "ARGUMENTS" else "OPTIONS"
     | Some s -> s

--- a/src/cmdliner.mli
+++ b/src/cmdliner.mli
@@ -443,7 +443,9 @@ module Arg : sig
       with [c0], [c1], [c2] and [c3]. *)
 end
 
-(** 
+val drop_posix_compat : unit -> unit
+
+(**
     {1:basics Basics}
 
     With [Cmdliner] your program evaluates a term. A {e term}


### PR DESCRIPTION
I would really like to use cmdliner for the ocsigen stack.
But I need cmdliner to drop POSIX compat for the following reason: 
- `eliomc` is a (light) wrapper arround `js_of_ocaml`/`ocamlc`/`ocamlfind` and pass some of its command line arguments directly to the subprocess. 
- ocamlfind and the ocaml compiler doesn't follow POSIX's `-oVALUE` convention.

Possible solutions:
- the PR get accepted :)
- fork :/
- keep posix and replace double dash ('--' -> '-') before passing argument to `ocamlfind`/`ocamlc`. :'(

One issue remains ! How to handle `ocamlc`/`js_of_ocaml` arguments inside `eliomc`.
- How to display help msg
- How to detect unknown arguments ?  
