### PR TITLE
Allow setting FMT via Term.info

### DIFF
--- a/src/cmdliner.ml
+++ b/src/cmdliner.ml
@@ -237,6 +237,7 @@ type man_block = [                                 (* block of manpage text. *)
 type term_info =
   { name : string;                                    (* name of the term. *)
     version : string option;                   (* version (for --version). *)
+    fmt: [`Pager | `Plain | `Groff];      (* man page format (for --help). *)
     tdoc : string;                        (* one line description of term. *)
     tdocs : string;       (* title of man section where listed (commands). *)
     sdocs : string;    (* standard options, title of section where listed. *)
@@ -1281,9 +1282,9 @@ module Term = struct
       | `Error of bool * string ]
 
   let info  ?(sdocs = "OPTIONS") ?(man = []) ?(docs = "COMMANDS") ?(doc = "")
-      ?version name =
+      ?version ?(fmt = `Pager) name =
     { name = name; version = version; tdoc = doc; tdocs = docs; sdocs = sdocs;
-      man = man }
+      man = man; fmt = fmt }
 
   let name ti = ti.name
   let const v = [], (fun _ _ -> v)
@@ -1330,10 +1331,12 @@ module Term = struct
     in
     let args, h_lookup =
       let (a, lookup) =
-        let fmt = Arg.enum ["pager",`Pager; "groff",`Groff; "plain",`Plain] in
+        let (ti, al) = ei.term in
+        let fmt = ti.fmt in
+        let fmts = Arg.enum ["pager",`Pager; "groff",`Groff; "plain",`Plain] in
         let doc = "Show this help in format $(docv) (pager, plain or groff)."in
         let a = Arg.info ["help"] ~docv:"FMT" ~docs ~doc in
-        Arg.opt ~vopt:(Some `Pager) (Arg.some fmt) None a
+        Arg.opt ~vopt:(Some fmt) (Arg.some fmts) None a
       in
       List.rev_append a args, lookup
     in

--- a/src/cmdliner.mli
+++ b/src/cmdliner.mli
@@ -138,11 +138,13 @@ module Term : sig
   (** The type for term information. *)
 
   val info : ?sdocs:string -> ?man:Manpage.block list ->
-    ?docs:string -> ?doc:string -> ?version:string -> string -> info
+    ?docs:string -> ?doc:string -> ?version:string ->
+    ?fmt:[`Pager | `Plain | `Groff] -> string -> info
   (** [info sdocs man docs doc version name] is a term information
       such that:
       {ul
       {- [name] is the name of the program or the command.}
+      {- [fmt] is the preferred man page format.}
       {- [version] is the version string of the program, ignored
          for commands.}
       {- [doc] is a one line description of the program or command used


### PR DESCRIPTION
Previously, the default FMT was set to `Pager` and there was no easy way to pass another format via `Term.info`. The workaround for this problem (e.g. `darcs` command example) involved re-implementing a print logic via `Manpage.print`, which was not ideal and was introducing an unnecessary amount of boiler-plate code.

This allows setting the `fmt` via `Term.info` as a quick way to customize the default pager option.