### PR TITLE
Add Term.capture to capture consumed arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tmp
 *.byte
 *.native
 cmdliner.install
+src/.merlin

--- a/cmdliner.opam
+++ b/cmdliner.opam
@@ -1,20 +1,20 @@
-opam-version: "1.2"
+opam-version: "2.0"
 maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
 homepage: "http://erratique.ch/software/cmdliner"
 doc: "http://erratique.ch/software/cmdliner/doc/Cmdliner"
-dev-repo: "http://erratique.ch/repos/cmdliner.git"
+dev-repo: "git+http://erratique.ch/repos/cmdliner.git"
 bug-reports: "https://github.com/dbuenzli/cmdliner/issues"
 tags: [ "cli" "system" "declarative" "org:erratique" ]
 license: "ISC"
-available: [ocaml-version >= "4.02.3"]
 depends:[
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
   "result"
+  "ocaml" {>= "4.02.3"}
 ]
 build: [[
   "ocaml" "pkg/pkg.ml" "build"
           "--pinned" "%{pinned}%"
-]]
+  ]]

--- a/dune-project
+++ b/dune-project
@@ -1,0 +1,2 @@
+(lang dune 1.4)
+(name cmdliner)

--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -30,4 +30,4 @@ let () =
        Pkg.test ~run:false "test/test_pos_req";
        Pkg.test ~run:false "test/test_opt_req";
        Pkg.test ~run:false "test/test_term_dups";
-       Pkg.test ~run:false "test/test_capture"; ]
+       Pkg.test ~run:false "test/test_with_evaluated_args"; ]

--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -26,4 +26,5 @@ let () =
        Pkg.test ~run:false "test/test_pos_left";
        Pkg.test ~run:false "test/test_pos_req";
        Pkg.test ~run:false "test/test_opt_req";
-       Pkg.test ~run:false "test/test_term_dups"; ]
+       Pkg.test ~run:false "test/test_term_dups";
+       Pkg.test ~run:false "test/test_capture"; ]

--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -9,8 +9,11 @@ let distrib =
   let exclude_paths () = Ok [".git";".gitignore";".gitattributes";"_build"] in
   Pkg.distrib ~exclude_paths ()
 
+let opams =
+  [Pkg.opam_file "cmdliner.opam"]
+
 let () =
-  Pkg.describe ~distrib "cmdliner" @@ fun c ->
+  Pkg.describe ~distrib "cmdliner" ~opams @@ fun c ->
   Ok [ Pkg.mllib ~api:["Cmdliner"] "src/cmdliner.mllib";
        test "test/chorus";
        test "test/cp_ex";

--- a/src/cmdliner.ml
+++ b/src/cmdliner.ml
@@ -51,6 +51,20 @@ module Term = struct
     Cmdliner_info.Args.empty,
     (fun ei _ -> Ok (List.rev_map choice_name (Cmdliner_info.eval_choices ei)))
 
+  let capture (al, v) : (_ * string list) t =
+    al, fun ei cl ->
+      match v ei cl with
+      | Ok x ->
+          let capture_args arg_info acc =
+            let args = Cmdliner_cline.actual_args cl arg_info in
+            List.rev_append args acc
+          in
+          let consumed_args =
+            List.rev (Cmdliner_info.Args.fold capture_args al [])
+          in
+          Ok (x, consumed_args)
+      | Error _ as e -> e
+
   (* Term information *)
 
   type exit_info = Cmdliner_info.exit

--- a/src/cmdliner.ml
+++ b/src/cmdliner.ml
@@ -51,7 +51,7 @@ module Term = struct
     Cmdliner_info.Args.empty,
     (fun ei _ -> Ok (List.rev_map choice_name (Cmdliner_info.eval_choices ei)))
 
-  let capture (al, v) : (_ * string list) t =
+  let with_evaluated_args (al, v) : (_ * string list) t =
     al, fun ei cl ->
       match v ei cl with
       | Ok x ->

--- a/src/cmdliner.mli
+++ b/src/cmdliner.mli
@@ -244,6 +244,11 @@ module Term : sig
   (** [choice_names] is a term that evaluates to the names of the terms
       to choose from. *)
 
+  val capture : 'a t -> ('a * string list) t
+  (** [capture t] is a term whose evaluation captures the actual
+      command line arguments passed by the user that are consumed by
+      [t]. *)
+
   (** {1:tinfo Term information}
 
       Term information defines the name and man page of a term.

--- a/src/cmdliner.mli
+++ b/src/cmdliner.mli
@@ -244,10 +244,10 @@ module Term : sig
   (** [choice_names] is a term that evaluates to the names of the terms
       to choose from. *)
 
-  val capture : 'a t -> ('a * string list) t
-  (** [capture t] is a term whose evaluation captures the actual
-      command line arguments passed by the user that are consumed by
-      [t]. *)
+  val with_evaluated_args : 'a t -> ('a * string list) t
+  (** [with_evaluated_args t] is a term whose evaluation returns the
+      arguments evaluated from the command line passed by the user that
+      are consumed by [t]. *)
 
   (** {1:tinfo Term information}
 

--- a/src/cmdliner_cline.ml
+++ b/src/cmdliner_cline.ml
@@ -30,6 +30,17 @@ let get_arg cl a = try Amap.find a cl with Not_found -> assert false
 let opt_arg cl a = match get_arg cl a with O l -> l | _ -> assert false
 let pos_arg cl a = match get_arg cl a with P l -> l | _ -> assert false
 
+let actual_args cl a =
+  match get_arg cl a with
+  | P args -> args
+  | O l ->
+      let extract_args (_pos, name, value) =
+        name :: (match value with
+          | None -> []
+          | Some v -> [v])
+      in
+      List.concat (List.map extract_args l)
+
 let arg_info_indexes args =
   (* from [args] returns a trie mapping the names of optional arguments to
      their arg_info, a list with all arg_info for positional arguments and

--- a/src/cmdliner_cline.mli
+++ b/src/cmdliner_cline.mli
@@ -17,8 +17,8 @@ val create :
 val opt_arg : t -> Cmdliner_info.arg -> (int * string * (string option)) list
 val pos_arg : t -> Cmdliner_info.arg -> string list
 
-(** Actual command line arguments from the command line *)
 val actual_args : t -> Cmdliner_info.arg -> string list
+(** Actual command line arguments from the command line *)
 
 (*---------------------------------------------------------------------------
    Copyright (c) 2011 Daniel C. Bünzli

--- a/src/cmdliner_cline.mli
+++ b/src/cmdliner_cline.mli
@@ -17,6 +17,9 @@ val create :
 val opt_arg : t -> Cmdliner_info.arg -> (int * string * (string option)) list
 val pos_arg : t -> Cmdliner_info.arg -> string list
 
+(** Actual command line arguments from the command line *)
+val actual_args : t -> Cmdliner_info.arg -> string list
+
 (*---------------------------------------------------------------------------
    Copyright (c) 2011 Daniel C. Bünzli
 

--- a/src/dune
+++ b/src/dune
@@ -1,0 +1,5 @@
+(library
+ (public_name cmdliner)
+ (libraries result)
+ (flags :standard -w -3-6-27-32-35)
+ (wrapped false))

--- a/src/jbuild
+++ b/src/jbuild
@@ -1,6 +1,0 @@
-(jbuild_version 1)
-(library
-  ((name cmdliner)
-   (public_name cmdliner)
-   (libraries (result))
-   (wrapped false)))

--- a/test/dune
+++ b/test/dune
@@ -1,0 +1,12 @@
+(executables
+ (names test_man
+        test_man_utf8
+        test_pos
+        test_pos_rev
+        test_pos_all
+        test_pos_left
+        test_pos_req
+        test_opt_req
+        test_term_dups
+        test_with_evaluated_args)
+ (libraries cmdliner))

--- a/test/test_capture.ml
+++ b/test/test_capture.ml
@@ -1,0 +1,18 @@
+open Cmdliner
+
+let print_args ((), args) _other =
+  print_endline (String.concat " " args)
+
+let test_pos_left =
+  let a = Arg.(value & flag & info ["a"; "aaa"]) in
+  let b = Arg.(value & opt (some string) None & info ["b"; "bbb"]) in
+  let c = Arg.(value & pos_all string [] & info []) in
+  let main =
+    let ignore_values _a _b _c = () in
+    Term.(capture (const ignore_values $ a $ b $ c))
+  in
+  let other = Arg.(value & flag & info ["other"]) in
+  Term.(const print_args $ main $ other),
+  Term.info "test_capture" ~doc:"Test pos left"
+
+let () = Term.(exit @@ eval test_pos_left)

--- a/test/test_with_evaluated_args.ml
+++ b/test/test_with_evaluated_args.ml
@@ -9,7 +9,7 @@ let test_pos_left =
   let c = Arg.(value & pos_all string [] & info []) in
   let main =
     let ignore_values _a _b _c = () in
-    Term.(capture (const ignore_values $ a $ b $ c))
+    Term.(with_evaluated_args (const ignore_values $ a $ b $ c))
   in
   let other = Arg.(value & flag & info ["other"]) in
   Term.(const print_args $ main $ other),


### PR DESCRIPTION
This PR implements the idea described in #101.

I added a test for the new feature, it captures the arguments `-a/--aaa`, `-b/--bbb` and positional arguments:

```
$ ./_build/test/test_capture.native -a 
-a
$ ./_build/test/test_capture.native --aaa
--aaa
$ ./_build/test/test_capture.native -b 0 -a
-a -b 0
$ ./_build/test/test_capture.native -b 0 x y z -a
-a -b 0 x y z
$ ./_build/test/test_capture.native -b 0 --other x y z -a
-a -b 0 x y z
```