### PR TITLE
Sort filenames before building

### DIFF
--- a/build.ml
+++ b/build.ml
@@ -120,6 +120,7 @@ let ocamldep () = really_find_cmd ["ocamldep.opt"; "ocamldep"]
 (* Build *)
 
 let sort_srcs srcs =
+  let srcs = List.sort String.compare srcs in
   read_cmd (ocamldep () :: "-slash" :: "-sort" :: srcs)
   |> String.trim |> cuts ~sep:' '
 


### PR DESCRIPTION
It's useful if building the same source code produces the same binaries, so that multiple people get the same result. I found that sometimes building qubes-mirage-firewall does not produce the expected sha256, and the difference in the ELF binary was in cmdliner symbols.

cmdliner's build system processes files in the order in which they are returned by `Sys.readdir`, which does not return them in any particular order. This patch sorts them first.