### PR TITLE
Allow to stop options parsing after first positional argument

### DIFF
--- a/src/cmdliner.mli
+++ b/src/cmdliner.mli
@@ -301,7 +301,7 @@ module Term : sig
   val info :
     ?man_xrefs:Manpage.xref list -> ?man:Manpage.block list ->
     ?envs:env_info list -> ?exits:exit_info list -> ?sdocs:string ->
-    ?docs:string -> ?doc:string -> ?version:string -> string -> info
+    ?docs:string -> ?doc:string -> ?version:string -> ?stop_on_pos:bool -> string -> info
   (** [info sdocs man docs doc version name] is a term information
       such that:
       {ul

--- a/src/cmdliner.mli
+++ b/src/cmdliner.mli
@@ -370,7 +370,7 @@ module Term : sig
       uses {!Sys.getenv}. *)
 
   val eval_choice :
-    ?help:Format.formatter -> ?err:Format.formatter -> ?catch:bool ->
+    ?help:Format.formatter -> ?err:Format.formatter -> ?catch:bool -> ?main_on_err:bool ->
     ?env:(string -> string option) -> ?argv:string array ->
     'a t * info -> ('a t * info) list -> 'a result
   (** [eval_choice help err catch argv (t,i) choices] is like {!eval}

--- a/src/cmdliner_cline.mli
+++ b/src/cmdliner_cline.mli
@@ -9,7 +9,7 @@
 type t
 
 val create :
-  ?peek_opts:bool -> Cmdliner_info.args -> string list ->
+  ?peek_opts:bool -> ?stop_on_pos:bool -> Cmdliner_info.args -> string list ->
   (t, string * t) result
 
 val opt_arg : t -> Cmdliner_info.arg -> (int * string * (string option)) list

--- a/src/cmdliner_info.ml
+++ b/src/cmdliner_info.ml
@@ -159,7 +159,8 @@ type term_info =
     term_exits : exit list;                      (* exit codes for the term. *)
     term_envs : env list;               (* env vars that influence the term. *)
     term_man : Cmdliner_manpage.block list;                (* man page text. *)
-    term_man_xrefs : Cmdliner_manpage.xref list; }        (* man cross-refs. *)
+    term_man_xrefs : Cmdliner_manpage.xref list;          (* man cross-refs. *)
+    term_stop_on_pos : bool; }        (* stop parsing opts on first pos arg. *)
 
 type term =
   { term_info : term_info;
@@ -170,10 +171,11 @@ let term
     ?man:(term_man = []) ?envs:(term_envs = []) ?exits:(term_exits = [])
     ?sdocs:(term_sdocs = Cmdliner_manpage.s_options)
     ?docs:(term_docs = "COMMANDS") ?doc:(term_doc = "") ?version:term_version
+    ?stop_on_pos:(term_stop_on_pos = false)
     term_name =
   let term_info =
     { term_name; term_version; term_doc; term_docs; term_sdocs; term_exits;
-      term_envs; term_man; term_man_xrefs }
+      term_envs; term_man; term_man_xrefs; term_stop_on_pos; }
   in
   { term_info; term_args }
 
@@ -187,6 +189,7 @@ let term_envs t = t.term_info.term_envs
 let term_man t = t.term_info.term_man
 let term_man_xrefs t = t.term_info.term_man_xrefs
 let term_args t = t.term_args
+let term_stop_on_pos t = t.term_info.term_stop_on_pos
 
 let term_add_args t args =
   { t with term_args = Args.union args t.term_args }

--- a/src/cmdliner_info.mli
+++ b/src/cmdliner_info.mli
@@ -92,6 +92,7 @@ val term :
   ?args:args -> ?man_xrefs:Cmdliner_manpage.xref list ->
   ?man:Cmdliner_manpage.block list -> ?envs:env list -> ?exits:exit list ->
   ?sdocs:string -> ?docs:string -> ?doc:string -> ?version:string ->
+  ?stop_on_pos:bool ->
   string -> term
 
 val term_name : term -> string
@@ -104,6 +105,7 @@ val term_envs : term -> env list
 val term_man : term -> Cmdliner_manpage.block list
 val term_man_xrefs : term -> Cmdliner_manpage.xref list
 val term_args : term -> args
+val term_stop_on_pos : term -> bool
 
 val term_add_args : term -> args -> term
 

--- a/test/dune
+++ b/test/dune
@@ -7,6 +7,7 @@
         test_pos_left
         test_pos_req
         test_opt_req
+        test_stop_on_pos
         test_term_dups
         test_with_used_args)
  (libraries cmdliner))

--- a/test/test_stop_on_pos.ml
+++ b/test/test_stop_on_pos.ml
@@ -1,0 +1,17 @@
+open Cmdliner
+
+let pos f o c =
+  let args = [] in
+  let args = if f then "-f"::args else args in
+  let args = match o with | None -> args | Some v -> "-o"::v::args in
+  print_endline (String.concat "\n" (args @ ["--"] @ c))
+
+let test_stop_on_pos =
+  let f = Arg.(value & flag & info ["f"]) in
+  let o = Arg.(value & opt (some string) None & info ["o"]) in
+  let c = Arg.(value & pos_all string [] & info [] ~docv:"COMMAND") in
+  Term.(const pos $ f $ o $ c),
+  Term.info "test_stop_on_pos" ~doc:"Test stop_on_pos arguments" ~stop_on_pos:true
+
+let () = Term.(exit @@ eval test_stop_on_pos)
+


### PR DESCRIPTION
`esy` is using a fork of cmdliner with[ two extra commits](https://github.com/esy-ocaml/cmdliner/commits/feat/stop_on_pos) to allow to stop parsing of options once a first posiitonal argument is detected. Which enables commands such as `esy dune build --help` instead of `esy -- dune build --help` to display the help of dune.

`dune` is also interested by this feature, as discussed there: https://github.com/ocaml/dune/issues/2038#issuecomment-486153110

But dune author would like to have this feature upstream. So here is the pull request.