### PR TITLE
New v_opt arguments and sequencing of terms.

### DIFF
--- a/src/cmdliner.ml
+++ b/src/cmdliner.ml
@@ -18,6 +18,7 @@ module Term = struct
   (* Terms *)
 
   let ( $ ) = app
+  let ( & ) = seq
 
   type 'a ret = [ `Ok of 'a | term_escape ]
 

--- a/src/cmdliner.mli
+++ b/src/cmdliner.mli
@@ -201,6 +201,12 @@ module Term : sig
   val app : ('a -> 'b) t -> 'a t -> 'b t
   (** [app] is {!($)}. *)
 
+  val ( & ) : 'a t -> 'b t -> 'b t
+  (** [v & v'] is a term that evaluates [v] and then evaluates [v']. *)
+
+  val seq : 'a t -> 'b t -> 'b t
+  (** [seq] is {!(&)}. *)
+
   (** {1 Interacting with Cmdliner's evaluation} *)
 
   type 'a ret =
@@ -648,6 +654,35 @@ module Arg : sig
       per occurrence of the flag in the order found on the command line.
       It holds the list [v] if the flag is absent from the command line. *)
 
+  val v_opt : 
+    ?vopt:'a -> ('a * 'b) -> ('a converter * 'b * info) list -> ('a * 'b) t
+  (** [vopt vopt (v, t) \[c]{_0}[t]{_0}[,i]{_0}[;...\]] is an ['a * 'b] argument
+      defined by the value of an optional argument that may appear {e at most}
+      once on the command line under one of the names specified in the [i]{_k} 
+      values. The argument holds [(v, t)] if the option is absent from the 
+      command line. Otherwise it is a pair of the value of the option (as 
+      converted by [c]{_k}) and [t]{_i}, where the name of the option present on
+      the command line is contained in [i]{_k}. 
+      The ['b] values serve as tags indicating which option was used.
+      
+      If [vopt] is provided the value of the optional argument is itself
+      optional, taking the value [vopt] if unspecified on the command line.
+
+      {b Note.} Environment variable lookup is unsupported for
+      for these arguments. *)
+
+  val v_opt_all : 
+    ?vopt:'a -> ('a * 'b) list -> ('a converter * 'b * info) list 
+      -> ('a * 'b) list t
+  (** [vopt_all vopt v \[c]{_0}[,t]{_0}[,i]{_0}[;...\]] is like {!vopt} except
+      that the optional argument may appear more than once. The argument holds a
+      list that contains one (value, tag) pair per occurrence of the flag in the
+      order found on the command line. It holds the list [v] if the flag is 
+      absent from the command line.
+
+      {b Note.} Environment variable lookup is unsupported for
+      for these arguments. *)
+      
   (** {1:posargs Positional arguments}
 
       The information of a positional argument must have no name

--- a/src/cmdliner_arg.mli
+++ b/src/cmdliner_arg.mli
@@ -43,6 +43,11 @@ val vflag : 'a -> ('a * info) list -> 'a t
 val vflag_all : 'a list -> ('a * info) list -> 'a list t
 val opt : ?vopt:'a -> 'a converter -> 'a -> info -> 'a t
 val opt_all : ?vopt:'a -> 'a converter -> 'a list -> info -> 'a list t
+val v_opt : 
+  ?vopt:'a -> ('a * 'b) -> ('a converter * 'b * info) list -> ('a * 'b) t
+val v_opt_all : 
+  ?vopt:'a -> ('a * 'b) list -> ('a converter * 'b * info) list 
+    -> ('a * 'b) list t
 
 val pos : ?rev:bool -> int -> 'a converter -> 'a -> info -> 'a t
 val pos_all : 'a converter -> 'a list -> info -> 'a list t

--- a/src/cmdliner_term.ml
+++ b/src/cmdliner_term.ml
@@ -23,6 +23,11 @@ let app (args_f, f) (args_v, v) =
       match v ei cl with
       | Error _ as e -> e
       | Ok v -> Ok (f v)
+let seq (args_v, v) (args_v', v') =
+  Cmdliner_info.Args.union args_v args_v',
+  fun ei cl -> match (v ei cl) with
+  | Error _ as e -> e
+  | Ok _ -> v' ei cl
 
 (*---------------------------------------------------------------------------
    Copyright (c) 2011 Daniel C. Bünzli

--- a/src/cmdliner_term.mli
+++ b/src/cmdliner_term.mli
@@ -22,6 +22,7 @@ type 'a t = Cmdliner_info.args * 'a parser
 
 val const : 'a -> 'a t
 val app : ('a -> 'b) t -> 'a t -> 'b t
+val seq : 'a t -> 'b t -> 'b t
 
 (*---------------------------------------------------------------------------
    Copyright (c) 2011 Daniel C. Bünzli

--- a/test/dune
+++ b/test/dune
@@ -8,5 +8,6 @@
         test_pos_req
         test_opt_req
         test_term_dups
+        test_v_opts
         test_with_used_args)
  (libraries cmdliner))

--- a/test/test_v_opts.ml
+++ b/test/test_v_opts.ml
@@ -1,0 +1,113 @@
+open Cmdliner
+
+let options =
+  let short_option =
+    let doc = "Print out $(docv) as a short option." in
+    let docv = "ARG" in
+    Arg.string, `Short, Arg.info ~doc ~docv ["s"] in
+  let long_option =
+    let doc = "Print out $(docv) as a long option." in
+    let docv = "ARG" in
+    Arg.string, `Long, Arg.info ~doc ~docv ["long"] in
+  [short_option; long_option]
+
+let show_args =
+  List.iter @@ function 
+  | (_, `NotPresent) ->
+    print_endline "Option not present"
+  | (v, `Short) ->
+    Format.printf "Short: %s\n" v
+  | (v, `Long) ->
+    Format.printf "Long: %s\n" v
+
+let show_arg v = 
+  show_args [v]
+  
+let v_opt_cmd =
+  let v_opt_term = 
+    Arg.(value & v_opt ("", `NotPresent) options) in
+  Term.(const show_arg $ v_opt_term)
+let v_opt_vopt_cmd =
+  let v_opt_vopt_term =
+    let vopt = "Default value" in
+    Arg.(value & v_opt ~vopt ("", `NotPresent) options) in
+  Term.(const show_arg $ v_opt_vopt_term)
+let v_opt_all_cmd =
+  let v_opt_all_term =
+    Arg.(value & v_opt_all [] options) in
+  Term.(const show_args $ v_opt_all_term)
+let v_opt_all_vopt_cmd =
+  let v_opt_all_vopt_term =
+    let vopt = "Default value" in
+    Arg.(value & v_opt_all ~vopt [] options) in
+  Term.(const show_args $ v_opt_all_vopt_term)
+
+let cmds = [
+    v_opt_cmd, Term.info ~doc:"At most one flag (no vopt)" "v_opt" ; 
+    v_opt_vopt_cmd, Term.info ~doc:"At most one flag (with vopt)" "v_opt_vopt" ; 
+    v_opt_all_cmd, Term.info ~doc:"All flags (no vopt)" "v_opt_all" ;
+    v_opt_all_vopt_cmd, Term.info ~doc:"All flags (with vopt)" "v_opt_all_vopt" ;
+  ]
+
+let default_cmd =
+  let doc = "Test program for the v_opt arguments" in
+  let sdocs = Cmdliner.Manpage.s_common_options in
+  let exits = Cmdliner.Term.default_exits in
+  Cmdliner.Term.(ret (const (fun _ -> `Help (`Pager, None)) $ v_opt_cmd)),
+  Cmdliner.Term.info "test_v_opt_all" ~doc ~sdocs ~exits
+
+let () = Cmdliner.Term.(exit @@ eval_choice default_cmd cmds)
+
+(* Test Output
+
+> ./test_v_opts.exe v_opt
+Option not present
+> ./test_v_opts.exe v_opt -s hello
+Short: hello
+> ./test_v_opts.exe v_opt -s hello --long world
+test_v_opt_all: options `-s' and `--long' cannot be present at the same time
+Usage: test_v_opt_all v_opt [OPTION]... 
+Try `test_v_opt_all v_opt --help' or `test_v_opt_all --help' for more information.
+
+> ./test_v_opts.exe v_opt_vopt
+Option not present
+> ./test_v_opts.exe v_opt_vopt -s hello
+Short: hello
+> ./test_v_opts.exe v_opt_vopt -s
+Short: Default value
+> ./test_v_opts.exe v_opt_vopt -s hello --long world
+test_v_opt_all: options `-s' and `--long' cannot be present at the same time
+Usage: test_v_opt_all v_opt_vopt [OPTION]... 
+Try `test_v_opt_all v_opt_vopt --help' or `test_v_opt_all --help' for more information.
+> ./test_v_opts.exe v_opt_vopt -s hello --long
+test_v_opt_all: options `-s' and `--long' cannot be present at the same time
+Usage: test_v_opt_all v_opt_vopt [OPTION]... 
+Try `test_v_opt_all v_opt_vopt --help' or `test_v_opt_all --help' for more information.
+> ./test_v_opts.exe v_opt_vopt --long
+Long: Default value
+> ./test_v_opts.exe v_opt_vopt --long world
+Long: world
+
+> ./test_v_opts.exe v_opt_all -s hello --long world
+Short: hello
+Long: world
+> ./test_v_opts.exe v_opt_all -s hello --long
+test_v_opt_all: option `--long' needs an argument
+Usage: test_v_opt_all v_opt_all [OPTION]... 
+Try `test_v_opt_all v_opt_all --help' or `test_v_opt_all --help' for more information.
+
+> ./test_v_opts.exe v_opt_all_vopt -s hello --long world
+Short: hello
+Long: world
+> ./test_v_opts.exe v_opt_all_vopt -s hello --long
+Short: hello
+Long: Default value
+> ./test_v_opts.exe v_opt_all_vopt -s --long
+Short: Default value
+Long: Default value
+> ./test_v_opts.exe v_opt_all_vopt -s --long -s
+Short: Default value
+Long: Default value
+Short: Default value
+
+*)


### PR DESCRIPTION
This adds two features to cmdliner, which I feel could be useful.

- A sequential composition combinator and associated operator for terms.
- Combinators for producing optional arguments that generalise the `opt` and `opt_all` combinators analogously to the way that the `vflag` and `vflag_all` combinators generalise the `flag` and `flag_all` combinators. Specifically, they allow different (collections of) option names to convert their arguments using different converters, and also specify different 'tag' values to associate with the arguments.