### PR TITLE
Escape absent value

### DIFF
--- a/src/cmdliner_docgen.ml
+++ b/src/cmdliner_docgen.ml
@@ -146,7 +146,7 @@ let arg_to_man_item ~errs ~subst ~buf a =
   | Cmdliner_info.Val v ->
       match Lazy.force v with
       | "" -> strf "%s" (or_env ~value:false a)
-      | v -> strf "absent=%s%s" v (or_env ~value:true a)
+      | v -> strf "absent=%s%s" (esc v) (or_env ~value:true a)
   in
   let optvopt = match Cmdliner_info.arg_opt_kind a with
   | Cmdliner_info.Opt_vopt v -> strf "default=%s" v


### PR DESCRIPTION
`opam admin cache --help` includes this snippet:

```
ARGUMENTS
       DIR (absent=~\opam\cache)
           Name of the cache directory to use.
```
but as the backslashes in the default value weren't escaped, that was causing output on stderr.