### PR TITLE
Allow arguments to commands in PAGER and MANPAGER.

### DIFF
--- a/src/cmdliner_manpage.ml
+++ b/src/cmdliner_manpage.ml
@@ -437,7 +437,15 @@ let find_cmd cmds =
   | "Win32" -> "where", " NUL"
   | _ -> "type", "/dev/null"
   in
-  let cmd c = Sys.command (strf "%s %s 1>%s 2>%s" test c null null) = 0 in
+  let trim_cmd c =
+    try
+      String.sub c 0 (String.index c ' ')
+    with Not_found -> c
+  in
+  let cmd c =
+    let c = trim_cmd c in
+    Sys.command (strf "%s %s 1>%s 2>%s" test c null null) = 0
+  in
   try Some (List.find cmd cmds) with Not_found -> None
 
 let pp_to_pager print ppf v =


### PR DESCRIPTION
The find_cmd function in cmdliner_manpage.ml runs the test command on commands listed in PAGER and MANPAGER.

If those environment variables contain commands with arguments, the test command returns with a non-zero status.

My current MANPAGER variable is set to "nvim +Man!" and hence doesn't get picked up by cmdliner. This is also true for "most -C" or "most -C -z" for example. 

This PR strips all arguments from the command prior to calling "test".

These were the test cases that I ran prior to and after the code changes.

export MANPAGER=""
export MANPAGER="most -C "
export MANPAGER="most -C -z"
export MANPAGER="nvim +Man!"

As a workaround it is currently also possible to just wrap the command in MANPAGER into a shell script.

I'm looking forward to feedback and suggestions.