### PR TITLE
Nested Commands #24

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,4 @@
-(lang dune 1.4)
+(lang dune 2.7)
 (name cmdliner)
+
+(cram enable)

--- a/src/cmdliner.ml
+++ b/src/cmdliner.ml
@@ -341,7 +341,14 @@ module Term = struct
         Cmdliner_msg.pp_err_usage err_ppf ei ~err_lines:false
           ~err:"this command has subcommands";
         `Error `Parse
-    | Error (`Invalid_command _) -> `Error `Exn
+    | Error (`Invalid_command (maybe, path, _choices)) ->
+        let err = Cmdliner_base.err_unknown ~kind:"command" maybe ~hints:[] in
+        let sibling_terms = List.map snd choices in
+        let ei = Cmdliner_info.eval ~env
+            (Sub_command { term = main ; path ; main ; sibling_terms})
+        in
+        Cmdliner_msg.pp_err_usage err_ppf ei ~err_lines:false ~err;
+        `Error `Parse
     | Ok (((_, f), info), sibling_terms, path, args) ->
         let sibling_terms = List.map snd sibling_terms in
         let ei = Cmdliner_info.eval ~env

--- a/src/cmdliner.ml
+++ b/src/cmdliner.ml
@@ -331,7 +331,7 @@ module Term = struct
         let err = Cmdliner_base.err_no_sub_command in
         let sibling_terms = List.map snd choices in
         let ei = Cmdliner_info.eval ~env
-            (Sub_command { term = main ; path ; main ; sibling_terms}) in
+            (Sub_command { path ; main ; sibling_terms}) in
         let help, version, ei = add_stdopts ei in
         let term_args = Cmdliner_info.(term_args @@ eval_term ei) in
         let args = remove_exec argv in
@@ -348,23 +348,22 @@ module Term = struct
     | Error (`Invalid_command (maybe, path, choices, hints)) ->
         let err = Cmdliner_base.err_unknown ~kind:"command" maybe ~hints in
         let sibling_terms = List.map snd choices in
-        let ei = Cmdliner_info.eval ~env
-            (Sub_command { term = main ; path ; main ; sibling_terms})
+        let ei =
+          Cmdliner_info.eval ~env (Sub_command { path ; main ; sibling_terms})
         in
         Cmdliner_msg.pp_err_usage err_ppf ei ~err_lines:false ~err;
         `Error `Parse
     | Error (`Ambiguous (cmd, path, ambs)) ->
         let err = Cmdliner_base.err_ambiguous ~kind:"command" cmd ~ambs in
         let sibling_terms = List.map snd choices in
-        let ei = Cmdliner_info.eval ~env
-            (Sub_command { term = main ; path ; main ; sibling_terms})
-        in
+        let ei =
+          Cmdliner_info.eval ~env (Sub_command { path ; main ; sibling_terms}) in
         Cmdliner_msg.pp_err_usage err_ppf ei ~err_lines:false ~err;
         `Error `Parse
     | Ok (((_, f), info), sibling_terms, path, args) ->
         let sibling_terms = List.map snd sibling_terms in
         let ei = Cmdliner_info.eval ~env
-            (Sub_command { main ; term = info ; path ; sibling_terms }) in
+            (Sub_command { main ; path ; sibling_terms }) in
         let ei, res = term_eval ~catch ei f args in
         do_result help_ppf err_ppf ei res
   end

--- a/src/cmdliner.ml
+++ b/src/cmdliner.ml
@@ -222,9 +222,9 @@ module Term = struct
     do_result help_ppf err_ppf ei res
 
   let choose_term main choices = function
-  | [] -> Ok (main, [])
+  | [] -> Ok (main, [], [fst main])
   | maybe :: args' as args ->
-      if String.length maybe > 1 && maybe.[0] = '-' then Ok (main, args) else
+      if String.length maybe > 1 && maybe.[0] = '-' then Ok (main, args, [fst main]) else
       let index =
         let add acc (choice, _ as c) =
           let name = Cmdliner_info.term_name choice in
@@ -235,7 +235,7 @@ module Term = struct
         List.fold_left add Cmdliner_trie.empty choices
       in
       match Cmdliner_trie.find index maybe with
-      | `Ok choice -> Ok (choice, args')
+      | `Ok choice -> Ok (choice, args', [fst main ; fst choice])
       | `Not_found ->
           let all = Cmdliner_trie.ambiguities index "" in
           let hints = Cmdliner_suggest.value maybe all in
@@ -263,9 +263,9 @@ module Term = struct
         in
         Cmdliner_msg.pp_err_usage err_ppf ei ~err_lines:false ~err;
         `Error `Parse
-    | Ok ((chosen, f), args) ->
+    | Ok ((chosen, f), args, path) ->
         let ei = Cmdliner_info.eval ~env
-            (Sub_command { term = chosen ; path = [main; chosen] ; main;
+            (Sub_command { term = chosen ; path ; main;
                            sibling_terms = choices }) in
         let ei, res = term_eval ~catch ei f args in
         do_result help_ppf err_ppf ei res

--- a/src/cmdliner.ml
+++ b/src/cmdliner.ml
@@ -235,7 +235,7 @@ module Term = struct
         List.fold_left add Cmdliner_trie.empty choices
       in
       match Cmdliner_trie.find index maybe with
-      | `Ok choice -> Ok (choice, args', [fst main ; fst choice])
+      | `Ok choice -> Ok (choice, args', [fst choice ; fst main])
       | `Not_found ->
           let all = Cmdliner_trie.ambiguities index "" in
           let hints = Cmdliner_suggest.value maybe all in
@@ -339,18 +339,7 @@ module Term = struct
     let choose_term main choices args =
       match parse_arg_cmd args with
       | Error `No_args -> Ok (main, choices, [], args)
-      | Ok (cmd, args) ->
-          match one_of (cmd, choices, [snd main], args) >>= choose_term with
-          | Ok (t, choices, path, args) -> Ok (t, choices, List.rev path, args)
-          | Error e ->
-              Error (
-                match e with
-                | `Invalid_command (cmd, path, choices, hint) ->
-                    `Invalid_command (cmd, List.rev path, choices, hint)
-                | `Ambiguous (cmd, path, ambs) ->
-                    `Ambiguous (cmd, List.rev path, ambs)
-                | `No_args (path, choices) ->
-                    `No_args (List.rev path, choices))
+      | Ok (cmd, args) -> one_of (cmd, choices, [snd main], args) >>= choose_term
 
     let eval
         ?help:(help_ppf = Format.std_formatter)

--- a/src/cmdliner.ml
+++ b/src/cmdliner.ml
@@ -363,10 +363,7 @@ module Term = struct
     let main = fst main_f in
     match choose_term (main_args, (fst main_f)) choices_f (remove_exec argv) with
     | Error (`No_args (path, choices)) ->
-        let err =
-          let name = List.map Cmdliner_info.term_name path in
-          Cmdliner_base.err_no_sub_command name
-        in
+        let err = Cmdliner_base.err_no_sub_command in
         let sibling_terms = List.map snd choices in
         let ei = Cmdliner_info.eval ~env
             (Sub_command { term = main ; path ; main ; sibling_terms}) in

--- a/src/cmdliner.ml
+++ b/src/cmdliner.ml
@@ -336,11 +336,10 @@ module Term = struct
     | Error (`No_args (path, choices)) ->
         let sibling_terms = List.map snd choices in
         let ei = Cmdliner_info.eval ~env
-            (Sub_command { term = main ; path ; main ; sibling_terms})
-        in
-        Cmdliner_msg.pp_err_usage err_ppf ei ~err_lines:false
-          ~err:"this command has subcommands";
-        `Error `Parse
+            (Sub_command { term = main ; path ; main ; sibling_terms}) in
+        let _, _, ei = add_stdopts ei in
+        Cmdliner_docgen.pp_man ~errs:err_ppf `Auto help_ppf ei;
+        `Help
     | Error (`Invalid_command (maybe, path, _choices)) ->
         let err = Cmdliner_base.err_unknown ~kind:"command" maybe ~hints:[] in
         let sibling_terms = List.map snd choices in

--- a/src/cmdliner.ml
+++ b/src/cmdliner.ml
@@ -312,9 +312,10 @@ module Term = struct
       | Group subs -> try_choose_term subs path args
 
     let choose_term main choices args =
+      let path = [snd main] in
       match parse_arg_cmd args with
-      | Error `No_args -> Ok (main, choices, [], args)
-      | Ok (cmd, args) -> one_of (cmd, choices, [snd main], args) >>= choose_term
+      | Error `No_args -> Ok (main, choices, path, args)
+      | Ok (cmd, args) -> one_of (cmd, choices, path, args) >>= choose_term
 
     let eval
         ?help:(help_ppf = Format.std_formatter)

--- a/src/cmdliner.mli
+++ b/src/cmdliner.mli
@@ -388,13 +388,23 @@ module Term : sig
     type 'a node =
     | Term of 'a term
     | Group of 'a t list
+    (** The type for an individual command or a command group.
+        {ul
+        {- [Term], individual command term.}
+        {- [Group], a list of command terms in the same group.}} *)
 
     and 'a t = 'a node * info
+    (** An individual command or a command group annotated with an [info] *)
 
     val eval :
       ?help:Format.formatter -> ?err:Format.formatter -> ?catch:bool ->
       ?env:(string -> string option) -> ?argv:string array ->
       'a term * info -> 'a t list -> 'a result
+    (** [eval help err catch argv (t, i) choices] is like {!eval_choice}
+        except that it will search for term inside the command group [choices]
+
+        If a command group is selected without a sub command, the program will
+        exit with an error message. *)
   end with type 'a term := 'a t
 
   val eval_peek_opts :

--- a/src/cmdliner.mli
+++ b/src/cmdliner.mli
@@ -382,6 +382,21 @@ module Term : sig
       is unspecified the "main" term [t] is evaluated. [i] defines the
       name and man page of the program. *)
 
+  module Group : sig
+    type 'a term
+
+    type 'a node =
+    | Term of 'a term
+    | Group of 'a t list
+
+    and 'a t = 'a node * info
+
+    val eval :
+      ?help:Format.formatter -> ?err:Format.formatter -> ?catch:bool ->
+      ?env:(string -> string option) -> ?argv:string array ->
+      'a term * info -> 'a t list -> 'a result
+  end with type 'a term := 'a t
+
   val eval_peek_opts :
     ?version_opt:bool -> ?env:(string -> string option) ->
     ?argv:string array -> 'a t -> 'a option * 'a result

--- a/src/cmdliner_base.ml
+++ b/src/cmdliner_base.ml
@@ -83,9 +83,8 @@ let err_unknown ?(hints = []) ~kind v =
   let hints = match hints with [] -> "." | hs -> did_you_mean (alts_str hs) in
   strf "unknown %s %s%s" kind (quote v) hints
 
-let err_no_sub_command cmd_path =
-  strf "%s is a command group and requires a command argument."
-    (String.concat " " cmd_path)
+let err_no_sub_command =
+  "is a command group and requires a command argument."
 
 let err_no kind s = strf "no %s %s" (quote s) kind
 let err_not_dir s = strf "%s is not a directory" (quote s)

--- a/src/cmdliner_base.ml
+++ b/src/cmdliner_base.ml
@@ -83,6 +83,10 @@ let err_unknown ?(hints = []) ~kind v =
   let hints = match hints with [] -> "." | hs -> did_you_mean (alts_str hs) in
   strf "unknown %s %s%s" kind (quote v) hints
 
+let err_no_sub_command cmd_path =
+  strf "%s is a command group and requires a command argument."
+    (String.concat " " cmd_path)
+
 let err_no kind s = strf "no %s %s" (quote s) kind
 let err_not_dir s = strf "%s is not a directory" (quote s)
 let err_is_dir s = strf "%s is a directory" (quote s)

--- a/src/cmdliner_base.mli
+++ b/src/cmdliner_base.mli
@@ -20,6 +20,7 @@ val err_ambiguous : kind:string -> string -> ambs:string list -> string
 val err_unknown : ?hints:string list -> kind:string -> string -> string
 val err_multi_def :
   kind:string -> string -> ('b -> string) -> 'b -> 'b -> string
+ val err_no_sub_command : string list -> string
 
 (** {1:conv Textual OCaml value converters} *)
 

--- a/src/cmdliner_base.mli
+++ b/src/cmdliner_base.mli
@@ -20,7 +20,7 @@ val err_ambiguous : kind:string -> string -> ambs:string list -> string
 val err_unknown : ?hints:string list -> kind:string -> string -> string
 val err_multi_def :
   kind:string -> string -> ('b -> string) -> 'b -> 'b -> string
- val err_no_sub_command : string list -> string
+ val err_no_sub_command : string
 
 (** {1:conv Textual OCaml value converters} *)
 

--- a/src/cmdliner_docgen.ml
+++ b/src/cmdliner_docgen.ml
@@ -61,9 +61,11 @@ let term_info_subst ei = function
 let invocation ?(sep = ' ') ei = match Cmdliner_info.eval_kind ei with
 | `Simple | `Multiple_main -> term_name (Cmdliner_info.eval_main ei)
 | `Multiple_sub ->
-    strf "%s%c%s"
-      Cmdliner_info.(term_name @@ eval_main ei) sep
-      Cmdliner_info.(term_name @@ eval_term ei)
+    let sep = String.make 1 sep in
+    Cmdliner_info.eval_parents_invocation_order ei
+    |> List.map Cmdliner_info.term_name
+    |> String.concat sep
+    |> strf "%s"
 
 let plain_invocation ei = invocation ei
 let invocation ?sep ei = esc @@ invocation ?sep ei

--- a/src/cmdliner_docgen.ml
+++ b/src/cmdliner_docgen.ml
@@ -62,7 +62,7 @@ let invocation ?(sep = ' ') ei = match Cmdliner_info.eval_kind ei with
 | `Simple | `Multiple_main -> term_name (Cmdliner_info.eval_main ei)
 | `Multiple_sub ->
     let sep = String.make 1 sep in
-    Cmdliner_info.eval_parents_invocation_order ei
+    Cmdliner_info.eval_terms ei
     |> List.map Cmdliner_info.term_name
     |> String.concat sep
     |> strf "%s"

--- a/src/cmdliner_docgen.ml
+++ b/src/cmdliner_docgen.ml
@@ -60,6 +60,7 @@ let term_info_subst ei = function
 
 let invocation ?(sep = ' ') ei = match Cmdliner_info.eval_kind ei with
 | `Simple | `Multiple_main -> term_name (Cmdliner_info.eval_main ei)
+| `Multiple_group
 | `Multiple_sub ->
     let sep = String.make 1 sep in
     Cmdliner_info.eval_terms_rev ei
@@ -83,6 +84,7 @@ let synopsis_pos_arg a =
 
 let synopsis ei = match Cmdliner_info.eval_kind ei with
 | `Multiple_main -> strf "$(b,%s) $(i,COMMAND) ..." @@ invocation ei
+| `Multiple_group
 | `Simple | `Multiple_sub ->
     let rev_cli_order (a0, _) (a1, _) =
       Cmdliner_info.rev_arg_pos_cli_order a0 a1
@@ -99,6 +101,7 @@ let synopsis ei = match Cmdliner_info.eval_kind ei with
 
 let cmd_docs ei = match Cmdliner_info.eval_kind ei with
 | `Simple | `Multiple_sub -> []
+| `Multiple_group
 | `Multiple_main ->
     let add_cmd acc t =
       let cmd = strf "$(b,%s)" @@ term_name t in

--- a/src/cmdliner_docgen.ml
+++ b/src/cmdliner_docgen.ml
@@ -62,8 +62,8 @@ let invocation ?(sep = ' ') ei = match Cmdliner_info.eval_kind ei with
 | `Simple | `Multiple_main -> term_name (Cmdliner_info.eval_main ei)
 | `Multiple_sub ->
     let sep = String.make 1 sep in
-    Cmdliner_info.eval_terms ei
-    |> List.map Cmdliner_info.term_name
+    Cmdliner_info.eval_terms_rev ei
+    |> List.rev_map Cmdliner_info.term_name
     |> String.concat sep
     |> strf "%s"
 

--- a/src/cmdliner_info.ml
+++ b/src/cmdliner_info.ml
@@ -219,6 +219,8 @@ let eval ~env kind =
         (main, term, path, sibling_terms)
   in
   { term; main; choices; env; path }
+
+let eval_terms e = e.path
 let eval_term e = e.term
 let eval_main e = e.main
 let eval_term_path e = e.path

--- a/src/cmdliner_info.ml
+++ b/src/cmdliner_info.ml
@@ -220,7 +220,6 @@ let eval ~env kind =
   in
   { term; main; choices; env; path }
 
-let eval_terms e = e.path
 let eval_term e = e.term
 let eval_main e = e.main
 let eval_term_path e = e.path
@@ -233,7 +232,7 @@ let eval_kind ei =
   if (ei.term.term_info.term_name == ei.main.term_info.term_name)
   then `Multiple_main else `Multiple_sub
 
-let eval_parents_invocation_order ei = List.rev ei.path
+let eval_terms_rev ei = ei.path
 
 let eval_with_term ei term = { ei with term }
 

--- a/src/cmdliner_info.ml
+++ b/src/cmdliner_info.ml
@@ -194,10 +194,7 @@ let term_add_args t args =
 type eval_kind =
 | Simple of term
 | Main of { term : term ; choices : term list }
-| Sub_command of { term : term;
-                   (** is [term] is from a group, [path] are the ancestors
-                        direct with the direct parent *)
-                   path : term list;
+| Sub_command of { path : term list;
                    main : term;
                    sibling_terms : term list }
 
@@ -215,7 +212,8 @@ let eval ~env kind =
     match kind with
     | Simple term -> (term, term, [term], [])
     | Main { term ; choices } -> (term, term, [term], choices)
-    | Sub_command { main ; term ; path ; sibling_terms } ->
+    | Sub_command { main ; path ; sibling_terms } ->
+        let term = List.hd path in
         (main, term, path, sibling_terms)
   in
   { term; main; choices; env; path }

--- a/src/cmdliner_info.ml
+++ b/src/cmdliner_info.ml
@@ -230,7 +230,12 @@ let eval_kind ei =
   (* subgroup *)
   if ei.choices = [] then `Simple else
   if (ei.term.term_info.term_name == ei.main.term_info.term_name)
-  then `Multiple_main else `Multiple_sub
+  then
+    match ei.path with
+    | [] -> assert false
+    | [_] -> `Multiple_main
+    | _ :: _ :: _ -> `Multiple_group
+  else `Multiple_sub
 
 let eval_terms_rev ei = ei.path
 

--- a/src/cmdliner_info.mli
+++ b/src/cmdliner_info.mli
@@ -127,7 +127,7 @@ val eval_term : eval -> term
 val eval_main : eval -> term
 val eval_choices : eval -> term list
 val eval_env_var : eval -> string -> string option
-val eval_kind : eval -> [> `Multiple_main | `Multiple_sub | `Simple ]
+val eval_kind : eval -> [> `Multiple_main | `Multiple_group | `Multiple_sub | `Simple ]
 val eval_with_term : eval -> term -> eval
 val eval_has_choice : eval -> string -> bool
 val eval_terms_rev : eval -> term list

--- a/src/cmdliner_info.mli
+++ b/src/cmdliner_info.mli
@@ -123,12 +123,9 @@ type eval_kind =
 
 val eval : env:(string -> string option) -> eval_kind -> eval
 
-(** Equivalent to [List.last (eval_term_full e)] *)
+val eval_terms : eval -> term list
 val eval_term : eval -> term
-
-(** Equivalent to [List.hd (eval_term_full e)] *)
 val eval_main : eval -> term
-
 val eval_choices : eval -> term list
 val eval_env_var : eval -> string -> string option
 val eval_kind : eval -> [> `Multiple_main | `Multiple_sub | `Simple ]

--- a/src/cmdliner_info.mli
+++ b/src/cmdliner_info.mli
@@ -123,7 +123,6 @@ type eval_kind =
 
 val eval : env:(string -> string option) -> eval_kind -> eval
 
-val eval_terms : eval -> term list
 val eval_term : eval -> term
 val eval_main : eval -> term
 val eval_choices : eval -> term list
@@ -131,7 +130,7 @@ val eval_env_var : eval -> string -> string option
 val eval_kind : eval -> [> `Multiple_main | `Multiple_sub | `Simple ]
 val eval_with_term : eval -> term -> eval
 val eval_has_choice : eval -> string -> bool
-val eval_parents_invocation_order : eval -> term list
+val eval_terms_rev : eval -> term list
 
 (*---------------------------------------------------------------------------
    Copyright (c) 2011 Daniel C. Bünzli

--- a/src/cmdliner_info.mli
+++ b/src/cmdliner_info.mli
@@ -114,11 +114,14 @@ type eval
 type eval_kind =
 | Simple of term
 | Main of { term : term ; choices : term list }
-| Sub_command of { path : term list ; sibling_terms : term list }
+| Sub_command of { term : term;
+                   (** is [term] is from a group, [path] are the ancestors
+                        direct with the direct parent *)
+                   path : term list;
+                   main : term;
+                   sibling_terms : term list }
 
 val eval : env:(string -> string option) -> eval_kind -> eval
-
-val eval_term_path : eval -> term list
 
 (** Equivalent to [List.last (eval_term_full e)] *)
 val eval_term : eval -> term
@@ -131,6 +134,7 @@ val eval_env_var : eval -> string -> string option
 val eval_kind : eval -> [> `Multiple_main | `Multiple_sub | `Simple ]
 val eval_with_term : eval -> term -> eval
 val eval_has_choice : eval -> string -> bool
+val eval_parents_invocation_order : eval -> term list
 
 (*---------------------------------------------------------------------------
    Copyright (c) 2011 Daniel C. Bünzli

--- a/src/cmdliner_info.mli
+++ b/src/cmdliner_info.mli
@@ -111,12 +111,21 @@ val term_add_args : term -> args -> term
 
 type eval
 
-val eval :
-  term:term -> main:term -> choices:term list ->
-  env:(string -> string option) -> eval
+type eval_kind =
+| Simple of term
+| Main of { term : term ; choices : term list }
+| Sub_command of { path : term list ; sibling_terms : term list }
 
+val eval : env:(string -> string option) -> eval_kind -> eval
+
+val eval_term_path : eval -> term list
+
+(** Equivalent to [List.last (eval_term_full e)] *)
 val eval_term : eval -> term
+
+(** Equivalent to [List.hd (eval_term_full e)] *)
 val eval_main : eval -> term
+
 val eval_choices : eval -> term list
 val eval_env_var : eval -> string -> string option
 val eval_kind : eval -> [> `Multiple_main | `Multiple_sub | `Simple ]

--- a/src/cmdliner_info.mli
+++ b/src/cmdliner_info.mli
@@ -114,10 +114,7 @@ type eval
 type eval_kind =
 | Simple of term
 | Main of { term : term ; choices : term list }
-| Sub_command of { term : term;
-                   (** is [term] is from a group, [path] are the ancestors
-                        direct with the direct parent *)
-                   path : term list;
+| Sub_command of { path : term list;
                    main : term;
                    sibling_terms : term list }
 

--- a/src/cmdliner_manpage.ml
+++ b/src/cmdliner_manpage.ml
@@ -23,6 +23,7 @@ let s_name = "NAME"
 let s_synopsis = "SYNOPSIS"
 let s_description = "DESCRIPTION"
 let s_commands = "COMMANDS"
+let s_command_aliases = "COMMAND ALIASES"
 let s_arguments = "ARGUMENTS"
 let s_options = "OPTIONS"
 let s_common_options = "COMMON OPTIONS"
@@ -45,7 +46,7 @@ let s_see_also = "SEE ALSO"
 let s_created = ""
 let order =
   [| s_name; s_synopsis; s_description; s_created; s_commands;
-     s_arguments; s_options; s_common_options; s_exit_status;
+     s_command_aliases; s_arguments; s_options; s_common_options; s_exit_status;
      s_environment; s_files; s_examples; s_bugs; s_authors; s_see_also; |]
 
 let order_synopsis = 1

--- a/src/cmdliner_msg.ml
+++ b/src/cmdliner_msg.ml
@@ -68,8 +68,9 @@ let err_arg_missing a =
 
 (* Other messages *)
 
-let exec_name ei =
-  Cmdliner_info.(String.concat " " (List.map term_name (eval_terms ei)))
+let exec_name_terms terms =
+  String.concat " " (List.rev_map Cmdliner_info.term_name terms)
+let exec_name ei = exec_name_terms (Cmdliner_info.eval_terms_rev ei)
 
 let pp_version ppf ei = match Cmdliner_info.(term_version @@ eval_main ei) with
 | None -> assert false
@@ -80,8 +81,13 @@ let pp_try_help ppf ei = match Cmdliner_info.eval_kind ei with
     pp ppf "@[<2>Try `%s --help' for more information.@]" (exec_name ei)
 | `Multiple_sub ->
     let exec_cmd = Cmdliner_docgen.plain_invocation ei in
+    let parent =
+      Cmdliner_info.eval_terms_rev ei
+      |> List.tl
+      |> exec_name_terms
+    in
     pp ppf "@[<2>Try `%s --help' or `%s --help' for more information.@]"
-      exec_cmd (exec_name ei)
+      exec_cmd parent
 
 let pp_err ppf ei ~err = pp ppf "%s: @[%a@]@." (exec_name ei) pp_lines err
 

--- a/src/cmdliner_msg.ml
+++ b/src/cmdliner_msg.ml
@@ -79,6 +79,7 @@ let pp_version ppf ei = match Cmdliner_info.(term_version @@ eval_main ei) with
 let pp_try_help ppf ei = match Cmdliner_info.eval_kind ei with
 | `Simple | `Multiple_main ->
     pp ppf "@[<2>Try `%s --help' for more information.@]" (exec_name ei)
+| `Multiple_group
 | `Multiple_sub ->
     let exec_cmd = Cmdliner_docgen.plain_invocation ei in
     let parent =

--- a/src/cmdliner_msg.ml
+++ b/src/cmdliner_msg.ml
@@ -68,7 +68,8 @@ let err_arg_missing a =
 
 (* Other messages *)
 
-let exec_name ei = Cmdliner_info.(term_name @@ eval_main ei)
+let exec_name ei =
+  Cmdliner_info.(String.concat " " (List.map term_name (eval_terms ei)))
 
 let pp_version ppf ei = match Cmdliner_info.(term_version @@ eval_main ei) with
 | None -> assert false

--- a/test/chorus.ml
+++ b/test/chorus.ml
@@ -2,7 +2,7 @@
 
 (* Implementation of the command *)
 
-let chorus count msg = for i = 1 to count do print_endline msg done
+let chorus count msg = for _ = 1 to count do print_endline msg done
 
 (* Command line interface *)
 

--- a/test/darcs.t
+++ b/test/darcs.t
@@ -1,13 +1,13 @@
   $ ./darcs_ex.exe --invalid opt
-  darcs: unknown option `--invalid'.
+  darcs darcs: unknown option `--invalid'.
   Usage: darcs COMMAND ...
-  Try `darcs --help' for more information.
+  Try `darcs darcs --help' for more information.
   [1]
 
   $ ./darcs_ex.exe initialize --invalid
-  darcs: unknown option `--invalid'.
+  darcs initialize: unknown option `--invalid'.
   Usage: initialize darcs [OPTION]... 
-  Try `initialize darcs --help' or `darcs --help' for more information.
+  Try `initialize darcs --help' or `darcs initialize --help' for more information.
   [1]
 
   $ ./darcs_ex.exe initialize --help

--- a/test/darcs.t
+++ b/test/darcs.t
@@ -1,7 +1,7 @@
   $ ./darcs_ex.exe --invalid opt
-  darcs darcs: unknown option `--invalid'.
+  darcs: unknown option `--invalid'.
   Usage: darcs COMMAND ...
-  Try `darcs darcs --help' for more information.
+  Try `darcs --help' for more information.
   [1]
 
   $ ./darcs_ex.exe initialize --invalid

--- a/test/darcs.t
+++ b/test/darcs.t
@@ -7,7 +7,7 @@
   $ ./darcs_ex.exe initialize --invalid
   darcs initialize: unknown option `--invalid'.
   Usage: darcs initialize [OPTION]... 
-  Try `darcs initialize --help' or `darcs initialize --help' for more information.
+  Try `darcs initialize --help' or `darcs --help' for more information.
   [1]
 
   $ ./darcs_ex.exe initialize --help

--- a/test/darcs.t
+++ b/test/darcs.t
@@ -1,0 +1,190 @@
+  $ ./darcs_ex.exe --invalid opt
+  darcs: unknown option `--invalid'.
+  Usage: darcs COMMAND ...
+  Try `darcs --help' for more information.
+  [1]
+
+  $ ./darcs_ex.exe initialize --invalid
+  darcs: unknown option `--invalid'.
+  Usage: darcs initialize [OPTION]... 
+  Try `darcs initialize --help' or `darcs --help' for more information.
+  [1]
+
+  $ ./darcs_ex.exe initialize --help
+  NAME
+         darcs-initialize - make the current directory a repository
+  
+  SYNOPSIS
+         darcs initialize [OPTION]... 
+  
+  DESCRIPTION
+         Turns the current directory into a Darcs repository. Any existing
+         files and subdirectories become ...
+  
+  OPTIONS
+         --repodir=DIR (absent=.)
+             Run the program in repository directory DIR.
+  
+  COMMON OPTIONS
+         These options are common to all commands.
+  
+         --debug
+             Give only debug output.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of `auto',
+             `pager', `groff' or `plain'. With `auto', the format is `pager` or
+             `plain' whenever the TERM env var is `dumb' or undefined.
+  
+         --prehook=VAL
+             Specify command to run before this darcs command.
+  
+         -q, --quiet
+             Suppress informational output.
+  
+         -v, --verbose
+             Give verbose output.
+  
+         --version
+             Show version information.
+  
+  MORE HELP
+         Use `darcs COMMAND --help' for help on a single command.
+         Use `darcs help patterns' for help on patch matching.
+         Use `darcs help environment' for help on environment variables.
+  
+  EXIT STATUS
+         initialize exits with the following status:
+  
+         0   on success.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
+  
+  BUGS
+         Check bug reports at http://bugs.example.org.
+  
+
+  $ TERM=dumb ./darcs_ex.exe
+  DARCS(1)                         Darcs Manual                         DARCS(1)
+  
+  
+  
+  NNAAMMEE
+         darcs - a revision control system
+  
+  SSYYNNOOPPSSIISS
+         ddaarrccss _C_O_M_M_A_N_D ...
+  
+  CCOOMMMMAANNDDSS
+         hheellpp
+             display help about darcs and darcs commands
+  
+         iinniittiiaalliizzee
+             make the current directory a repository
+  
+         rreeccoorrdd
+             create a patch from unrecorded changes
+  
+  CCOOMMMMOONN OOPPTTIIOONNSS
+         These options are common to all commands.
+  
+         ----ddeebbuugg
+             Give only debug output.
+  
+         ----hheellpp[=_F_M_T] (default=auto)
+             Show this help in format _F_M_T. The value _F_M_T must be one of `auto',
+             `pager', `groff' or `plain'. With `auto', the format is `pager` or
+             `plain' whenever the TTEERRMM env var is `dumb' or undefined.
+  
+         ----pprreehhooookk=_V_A_L
+             Specify command to run before this ddaarrccss command.
+  
+         --qq, ----qquuiieett
+             Suppress informational output.
+  
+         --vv, ----vveerrbboossee
+             Give verbose output.
+  
+         ----vveerrssiioonn
+             Show version information.
+  
+  MMOORREE HHEELLPP
+         Use `ddaarrccss _C_O_M_M_A_N_D --help' for help on a single command.
+         Use `ddaarrccss help patterns' for help on patch matching.
+         Use `ddaarrccss help environment' for help on environment variables.
+  
+  EEXXIITT SSTTAATTUUSS
+         ddaarrccss exits with the following status:
+  
+         0   on success.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
+  
+  BBUUGGSS
+         Check bug reports at http://bugs.example.org.
+  
+  
+  
+  Darcs 11VERSION11                                                     DARCS(1)
+
+  $ ./darcs_ex.exe --help
+  NAME
+         darcs - a revision control system
+  
+  SYNOPSIS
+         darcs COMMAND ...
+  
+  COMMANDS
+         help
+             display help about darcs and darcs commands
+  
+         initialize
+             make the current directory a repository
+  
+         record
+             create a patch from unrecorded changes
+  
+  COMMON OPTIONS
+         These options are common to all commands.
+  
+         --debug
+             Give only debug output.
+  
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of `auto',
+             `pager', `groff' or `plain'. With `auto', the format is `pager` or
+             `plain' whenever the TERM env var is `dumb' or undefined.
+  
+         --prehook=VAL
+             Specify command to run before this darcs command.
+  
+         -q, --quiet
+             Suppress informational output.
+  
+         -v, --verbose
+             Give verbose output.
+  
+         --version
+             Show version information.
+  
+  MORE HELP
+         Use `darcs COMMAND --help' for help on a single command.
+         Use `darcs help patterns' for help on patch matching.
+         Use `darcs help environment' for help on environment variables.
+  
+  EXIT STATUS
+         darcs exits with the following status:
+  
+         0   on success.
+  
+         124 on command line parsing errors.
+  
+         125 on unexpected internal errors (bugs).
+  
+  BUGS
+         Check bug reports at http://bugs.example.org.
+  

--- a/test/darcs.t
+++ b/test/darcs.t
@@ -1,7 +1,7 @@
   $ ./darcs_ex.exe --invalid opt
-  : unknown option `--invalid'.
+  darcs: unknown option `--invalid'.
   Usage: darcs COMMAND ...
-  Try ` --help' for more information.
+  Try `darcs --help' for more information.
   [1]
 
   $ ./darcs_ex.exe initialize --invalid

--- a/test/darcs.t
+++ b/test/darcs.t
@@ -6,16 +6,16 @@
 
   $ ./darcs_ex.exe initialize --invalid
   darcs initialize: unknown option `--invalid'.
-  Usage: initialize darcs [OPTION]... 
-  Try `initialize darcs --help' or `darcs initialize --help' for more information.
+  Usage: darcs initialize [OPTION]... 
+  Try `darcs initialize --help' or `darcs initialize --help' for more information.
   [1]
 
   $ ./darcs_ex.exe initialize --help
   NAME
-         initialize-darcs - make the current directory a repository
+         darcs-initialize - make the current directory a repository
   
   SYNOPSIS
-         initialize darcs [OPTION]... 
+         darcs initialize [OPTION]... 
   
   DESCRIPTION
          Turns the current directory into a Darcs repository. Any existing

--- a/test/darcs.t
+++ b/test/darcs.t
@@ -6,16 +6,16 @@
 
   $ ./darcs_ex.exe initialize --invalid
   darcs: unknown option `--invalid'.
-  Usage: darcs initialize [OPTION]... 
-  Try `darcs initialize --help' or `darcs --help' for more information.
+  Usage: initialize darcs [OPTION]... 
+  Try `initialize darcs --help' or `darcs --help' for more information.
   [1]
 
   $ ./darcs_ex.exe initialize --help
   NAME
-         darcs-initialize - make the current directory a repository
+         initialize-darcs - make the current directory a repository
   
   SYNOPSIS
-         darcs initialize [OPTION]... 
+         initialize darcs [OPTION]... 
   
   DESCRIPTION
          Turns the current directory into a Darcs repository. Any existing

--- a/test/darcs.t
+++ b/test/darcs.t
@@ -1,7 +1,7 @@
   $ ./darcs_ex.exe --invalid opt
-  darcs: unknown option `--invalid'.
+  : unknown option `--invalid'.
   Usage: darcs COMMAND ...
-  Try `darcs --help' for more information.
+  Try ` --help' for more information.
   [1]
 
   $ ./darcs_ex.exe initialize --invalid

--- a/test/darcs_ex.ml
+++ b/test/darcs_ex.ml
@@ -23,7 +23,7 @@ let record copts name email all ask_deps files = Printf.printf
     pr_copts copts (opt_str_str name) (opt_str_str email) all ask_deps
     (String.concat ", " files)
 
-let help copts man_format cmds topic = match topic with
+let help _copts man_format cmds topic = match topic with
 | None -> `Help (`Pager, None) (* help about the program. *)
 | Some topic ->
     let topics = "topics" :: "patterns" :: "environment" :: cmds in
@@ -32,7 +32,7 @@ let help copts man_format cmds topic = match topic with
     | `Error e -> `Error (false, e)
     | `Ok t when t = "topics" -> List.iter print_endline topics; `Ok ()
     | `Ok t when List.mem t cmds -> `Help (man_format, Some t)
-    | `Ok t ->
+    | `Ok _ ->
         let page = (topic, 7, "", "", ""), [`S topic; `P "Say something";] in
         `Ok (Cmdliner.Manpage.print man_format Format.std_formatter page)
 

--- a/test/dune
+++ b/test/dune
@@ -8,5 +8,14 @@
         test_pos_req
         test_opt_req
         test_term_dups
-        test_with_used_args)
+        test_with_used_args
+        darcs_ex)
  (libraries cmdliner))
+
+(cram
+ (applies_to groups)
+ (deps ./groups.exe))
+
+(cram
+ (applies_to darcs)
+ (deps ./darcs_ex.exe))

--- a/test/dune
+++ b/test/dune
@@ -9,6 +9,7 @@
         test_opt_req
         test_term_dups
         test_with_used_args
+        groups
         darcs_ex)
  (libraries cmdliner))
 

--- a/test/groups.ml
+++ b/test/groups.ml
@@ -35,6 +35,7 @@ let cmds :  _ Term.Group.t list =
   let _term (t, info) = Term.Group.Term t, info in
   [ gen_group "things"
   ; gen_group "widgets"
+  ; gen_group "widg"
   ]
 
 let () =

--- a/test/groups.ml
+++ b/test/groups.ml
@@ -1,6 +1,6 @@
 open Cmdliner
 
-let things =
+let gen_group name =
   let thing =
     let doc = "thing to operate on" in
     let nfo = Arg.info ~doc [] in
@@ -11,7 +11,7 @@ let things =
     Term.(const show $ thing)
   in
   let list =
-    let list () = print_endline "listing things" in
+    let list () = Printf.printf "listing %s\n" name in
     Term.(const list $ (const ()))
   in
   let term : _ Term.Group.t list =
@@ -19,7 +19,7 @@ let things =
     ; Term list, Term.info "list"
     ]
   in
-  (Term.Group.Group term), Term.info "things"
+  (Term.Group.Group term), Term.info name
 
 let default_cmd =
   let term =
@@ -33,7 +33,8 @@ let default_cmd =
 
 let cmds :  _ Term.Group.t list =
   let _term (t, info) = Term.Group.Term t, info in
-  [ things
+  [ gen_group "things"
+  ; gen_group "widgets"
   ]
 
 let () =

--- a/test/groups.ml
+++ b/test/groups.ml
@@ -19,7 +19,13 @@ let gen_group name =
     ; Term list, Term.info "list"
     ]
   in
-  (Term.Group.Group term), Term.info name
+  let man =
+    [ `S "DESCRIPTION"
+    ; `P (Printf.sprintf "description of %S" name)
+    ]
+  in
+  let doc = Printf.sprintf "doc for %S" name in
+  (Term.Group.Group term), Term.info ~doc ~man name
 
 let default_cmd =
   let term =
@@ -29,7 +35,13 @@ let default_cmd =
     in
     Term.(ret (const run $ (const ())))
   in
-  term, Term.info "groups" ~version:"%%VERSION%%"
+  let doc = "default term doc" in
+  let man =
+    [ `S "DESCRIPTION"
+    ; `P "description of default term"
+    ]
+  in
+  term, Term.info "groups" ~version:"%%VERSION%%" ~doc ~man
 
 let cmds :  _ Term.Group.t list =
   let _term (t, info) = Term.Group.Term t, info in

--- a/test/groups.ml
+++ b/test/groups.ml
@@ -1,0 +1,40 @@
+open Cmdliner
+
+let things =
+  let thing =
+    let doc = "thing to operate on" in
+    let nfo = Arg.info ~doc [] in
+     Arg.(required & pos 0 (some string) None & nfo ) in
+  let show =
+    let show thing =
+      Printf.printf "showing %s\n" thing in
+    Term.(const show $ thing)
+  in
+  let list =
+    let list () = print_endline "listing things" in
+    Term.(const list $ (const ()))
+  in
+  let term : _ Term.Group.t list =
+    [ Term show, Term.info "show"
+    ; Term list, Term.info "list"
+    ]
+  in
+  (Term.Group.Group term), Term.info "things"
+
+let default_cmd =
+  let term =
+    let run () =
+      print_endline "default cmd";
+        `Ok ()
+    in
+    Term.(ret (const run $ (const ())))
+  in
+  term, Term.info "groups" ~version:"%%VERSION%%"
+
+let cmds :  _ Term.Group.t list =
+  let _term (t, info) = Term.Group.Term t, info in
+  [ things
+  ]
+
+let () =
+  Term.(exit @@ Term.Group.eval default_cmd cmds)

--- a/test/groups.t
+++ b/test/groups.t
@@ -80,3 +80,8 @@ Prefixes
   Usage: groups COMMAND ...
   Try `groups --help' for more information.
   [124]
+
+Default cmd
+
+  $ ./groups.exe
+  default cmd

--- a/test/groups.t
+++ b/test/groups.t
@@ -1,0 +1,34 @@
+  $ ./groups.exe things list
+  listing things
+
+  $ ./groups.exe things
+  Fatal error: exception File "src/cmdliner.ml", line 318, characters 24-30: Assertion failed
+  [2]
+
+  $ ./groups.exe things show foo
+  showing foo
+
+  $ ./groups.exe things list --help
+  NAME
+         groups
+  
+  SYNOPSIS
+         groups [OPTION]... 
+  
+  OPTIONS
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of `auto',
+             `pager', `groff' or `plain'. With `auto', the format is `pager` or
+             `plain' whenever the TERM env var is `dumb' or undefined.
+  
+         --version
+             Show version information.
+  
+
+  $ ./groups.exe things --help
+  Fatal error: exception File "src/cmdliner.ml", line 318, characters 24-30: Assertion failed
+  [2]
+
+  $ ./groups.exe --help
+  Fatal error: exception File "src/cmdliner.ml", line 318, characters 24-30: Assertion failed
+  [2]

--- a/test/groups.t
+++ b/test/groups.t
@@ -77,6 +77,8 @@
   COMMANDS
          things
   
+         widg
+  
          widgets
   
   
@@ -98,6 +100,17 @@
 
   $ ./groups.exe widgets baz
   groups: unknown command `baz'.
+  Usage: groups COMMAND ...
+  Try `groups --help' for more information.
+  [124]
+
+Prefixes
+
+  $ ./groups.exe th show foo
+  showing foo
+
+  $ ./groups.exe wid show foo
+  groups: command `wid' ambiguous and could be either `widg' or `widgets'
   Usage: groups COMMAND ...
   Try `groups --help' for more information.
   [124]

--- a/test/groups.t
+++ b/test/groups.t
@@ -2,27 +2,10 @@
   listing things
 
   $ ./groups.exe things
-  NAME
-         groups
-  
-  SYNOPSIS
-         groups COMMAND ...
-  
-  COMMANDS
-         list
-  
-         show
-  
-  
-  OPTIONS
-         --help[=FMT] (default=auto)
-             Show this help in format FMT. The value FMT must be one of `auto',
-             `pager', `groff' or `plain'. With `auto', the format is `pager` or
-             `plain' whenever the TERM env var is `dumb' or undefined.
-  
-         --version
-             Show version information.
-  
+  groups: things groups is a command group and requires a command argument.
+  Usage: groups COMMAND ...
+  Try `groups --help' for more information.
+  [124]
 
   $ ./groups.exe things show foo
   showing foo
@@ -45,27 +28,10 @@
   
 
   $ ./groups.exe things --help
-  NAME
-         groups
-  
-  SYNOPSIS
-         groups COMMAND ...
-  
-  COMMANDS
-         list
-  
-         show
-  
-  
-  OPTIONS
-         --help[=FMT] (default=auto)
-             Show this help in format FMT. The value FMT must be one of `auto',
-             `pager', `groff' or `plain'. With `auto', the format is `pager` or
-             `plain' whenever the TERM env var is `dumb' or undefined.
-  
-         --version
-             Show version information.
-  
+  groups: things groups is a command group and requires a command argument.
+  Usage: groups COMMAND ...
+  Try `groups --help' for more information.
+  [124]
 
   $ ./groups.exe --help
   NAME

--- a/test/groups.t
+++ b/test/groups.t
@@ -55,3 +55,15 @@
          --version
              Show version information.
   
+
+  $ ./groups.exe foobar
+  groups: unknown command `foobar'.
+  Usage: groups COMMAND ...
+  Try `groups --help' for more information.
+  [124]
+
+  $ ./groups.exe widgets baz
+  groups: unknown command `baz'.
+  Usage: groups COMMAND ...
+  Try `groups --help' for more information.
+  [124]

--- a/test/groups.t
+++ b/test/groups.t
@@ -29,10 +29,13 @@
 
   $ ./groups.exe things --help
   NAME
-         groups-things
+         groups-things - default term doc
   
   SYNOPSIS
          groups things [OPTION]... 
+  
+  DESCRIPTION
+         description of default term
   
   COMMANDS
          list
@@ -58,18 +61,23 @@
 
   $ ./groups.exe --help
   NAME
-         groups
+         groups - default term doc
   
   SYNOPSIS
          groups COMMAND ...
   
+  DESCRIPTION
+         description of default term
+  
   COMMANDS
          things
+             doc for "things"
   
          widg
+             doc for "widg"
   
          widgets
-  
+             doc for "widgets"
   
   OPTIONS
          --help[=FMT] (default=auto)

--- a/test/groups.t
+++ b/test/groups.t
@@ -2,9 +2,10 @@
   listing things
 
   $ ./groups.exe things
-  groups: things groups is a command group and requires a command argument.
+  things groups: things groups is a command group and requires a command
+                 argument.
   Usage: groups COMMAND ...
-  Try `groups --help' for more information.
+  Try `things groups --help' for more information.
   [124]
 
   $ ./groups.exe things show foo
@@ -28,9 +29,10 @@
   
 
   $ ./groups.exe things --help
-  groups: things groups is a command group and requires a command argument.
+  things groups: things groups is a command group and requires a command
+                 argument.
   Usage: groups COMMAND ...
-  Try `groups --help' for more information.
+  Try `things groups --help' for more information.
   [124]
 
   $ ./groups.exe --help
@@ -65,9 +67,9 @@
   [124]
 
   $ ./groups.exe widgets baz
-  groups: unknown command `baz'.
+  widgets groups: unknown command `baz'.
   Usage: groups COMMAND ...
-  Try `groups --help' for more information.
+  Try `widgets groups --help' for more information.
   [124]
 
 Prefixes

--- a/test/groups.t
+++ b/test/groups.t
@@ -2,7 +2,7 @@
   listing things
 
   $ ./groups.exe things
-  Fatal error: exception File "src/cmdliner.ml", line 334, characters 24-30: Assertion failed
+  Fatal error: exception File "src/cmdliner.ml", line 336, characters 42-48: Assertion failed
   [2]
 
   $ ./groups.exe things show foo
@@ -10,10 +10,10 @@
 
   $ ./groups.exe things list --help
   NAME
-         groups
+         groups-list
   
   SYNOPSIS
-         groups [OPTION]... 
+         groups list [OPTION]... 
   
   OPTIONS
          --help[=FMT] (default=auto)
@@ -26,7 +26,7 @@
   
 
   $ ./groups.exe things --help
-  Fatal error: exception File "src/cmdliner.ml", line 334, characters 24-30: Assertion failed
+  Fatal error: exception File "src/cmdliner.ml", line 336, characters 42-48: Assertion failed
   [2]
 
   $ ./groups.exe --help
@@ -34,7 +34,11 @@
          groups
   
   SYNOPSIS
-         groups [OPTION]... 
+         groups COMMAND ...
+  
+  COMMANDS
+         things
+  
   
   OPTIONS
          --help[=FMT] (default=auto)

--- a/test/groups.t
+++ b/test/groups.t
@@ -2,10 +2,27 @@
   listing things
 
   $ ./groups.exe things
-  groups: this command has subcommands
-  Usage: groups COMMAND ...
-  Try `groups --help' for more information.
-  [124]
+  NAME
+         groups
+  
+  SYNOPSIS
+         groups COMMAND ...
+  
+  COMMANDS
+         list
+  
+         show
+  
+  
+  OPTIONS
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of `auto',
+             `pager', `groff' or `plain'. With `auto', the format is `pager` or
+             `plain' whenever the TERM env var is `dumb' or undefined.
+  
+         --version
+             Show version information.
+  
 
   $ ./groups.exe things show foo
   showing foo
@@ -28,10 +45,27 @@
   
 
   $ ./groups.exe things --help
-  groups: this command has subcommands
-  Usage: groups COMMAND ...
-  Try `groups --help' for more information.
-  [124]
+  NAME
+         groups
+  
+  SYNOPSIS
+         groups COMMAND ...
+  
+  COMMANDS
+         list
+  
+         show
+  
+  
+  OPTIONS
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of `auto',
+             `pager', `groff' or `plain'. With `auto', the format is `pager` or
+             `plain' whenever the TERM env var is `dumb' or undefined.
+  
+         --version
+             Show version information.
+  
 
   $ ./groups.exe --help
   NAME

--- a/test/groups.t
+++ b/test/groups.t
@@ -2,8 +2,7 @@
   listing things
 
   $ ./groups.exe things
-  groups things: groups things is a command group and requires a command
-                 argument.
+  groups things: is a command group and requires a command argument.
   Usage: groups COMMAND ...
   Try `groups things --help' for more information.
   [124]
@@ -29,8 +28,7 @@
   
 
   $ ./groups.exe things --help
-  groups things: groups things is a command group and requires a command
-                 argument.
+  groups things: is a command group and requires a command argument.
   Usage: groups COMMAND ...
   Try `groups things --help' for more information.
   [124]

--- a/test/groups.t
+++ b/test/groups.t
@@ -3,8 +3,8 @@
 
   $ ./groups.exe things
   groups things: is a command group and requires a command argument.
-  Usage: groups COMMAND ...
-  Try `groups things --help' for more information.
+  Usage: groups things [OPTION]... 
+  Try `groups things --help' or `groups --help' for more information.
   [124]
 
   $ ./groups.exe things show foo
@@ -28,9 +28,32 @@
   
 
   $ ./groups.exe things --help
+  NAME
+         groups-things
+  
+  SYNOPSIS
+         groups things [OPTION]... 
+  
+  COMMANDS
+         list
+  
+         show
+  
+  
+  OPTIONS
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of `auto',
+             `pager', `groff' or `plain'. With `auto', the format is `pager` or
+             `plain' whenever the TERM env var is `dumb' or undefined.
+  
+         --version
+             Show version information.
+  
+
+  $ ./groups.exe things --invalid-arg
   groups things: is a command group and requires a command argument.
-  Usage: groups COMMAND ...
-  Try `groups things --help' for more information.
+  Usage: groups things [OPTION]... 
+  Try `groups things --help' or `groups --help' for more information.
   [124]
 
   $ ./groups.exe --help
@@ -66,8 +89,8 @@
 
   $ ./groups.exe widgets baz
   groups widgets: unknown command `baz'.
-  Usage: groups COMMAND ...
-  Try `groups widgets --help' for more information.
+  Usage: groups widgets [OPTION]... 
+  Try `groups widgets --help' or `groups --help' for more information.
   [124]
 
 Prefixes
@@ -85,3 +108,10 @@ Default cmd
 
   $ ./groups.exe
   default cmd
+
+Version
+
+  $ ./groups.exe things --version
+  %%VERSION%%
+  $ ./groups.exe things list --version
+  %%VERSION%%

--- a/test/groups.t
+++ b/test/groups.t
@@ -2,10 +2,10 @@
   listing things
 
   $ ./groups.exe things
-  things groups: things groups is a command group and requires a command
+  groups things: groups things is a command group and requires a command
                  argument.
   Usage: groups COMMAND ...
-  Try `things groups --help' for more information.
+  Try `groups things --help' for more information.
   [124]
 
   $ ./groups.exe things show foo
@@ -29,10 +29,10 @@
   
 
   $ ./groups.exe things --help
-  things groups: things groups is a command group and requires a command
+  groups things: groups things is a command group and requires a command
                  argument.
   Usage: groups COMMAND ...
-  Try `things groups --help' for more information.
+  Try `groups things --help' for more information.
   [124]
 
   $ ./groups.exe --help
@@ -67,9 +67,9 @@
   [124]
 
   $ ./groups.exe widgets baz
-  widgets groups: unknown command `baz'.
+  groups widgets: unknown command `baz'.
   Usage: groups COMMAND ...
-  Try `widgets groups --help' for more information.
+  Try `groups widgets --help' for more information.
   [124]
 
 Prefixes

--- a/test/groups.t
+++ b/test/groups.t
@@ -29,19 +29,13 @@
 
   $ ./groups.exe things --help
   NAME
-         groups-things - default term doc
+         groups-things - doc for "things"
   
   SYNOPSIS
          groups things [OPTION]... 
   
   DESCRIPTION
-         description of default term
-  
-  COMMANDS
-         list
-  
-         show
-  
+         description of "things"
   
   OPTIONS
          --help[=FMT] (default=auto)

--- a/test/groups.t
+++ b/test/groups.t
@@ -2,7 +2,7 @@
   listing things
 
   $ ./groups.exe things
-  Fatal error: exception File "src/cmdliner.ml", line 318, characters 24-30: Assertion failed
+  Fatal error: exception File "src/cmdliner.ml", line 334, characters 24-30: Assertion failed
   [2]
 
   $ ./groups.exe things show foo
@@ -26,9 +26,22 @@
   
 
   $ ./groups.exe things --help
-  Fatal error: exception File "src/cmdliner.ml", line 318, characters 24-30: Assertion failed
+  Fatal error: exception File "src/cmdliner.ml", line 334, characters 24-30: Assertion failed
   [2]
 
   $ ./groups.exe --help
-  Fatal error: exception File "src/cmdliner.ml", line 318, characters 24-30: Assertion failed
-  [2]
+  NAME
+         groups
+  
+  SYNOPSIS
+         groups [OPTION]... 
+  
+  OPTIONS
+         --help[=FMT] (default=auto)
+             Show this help in format FMT. The value FMT must be one of `auto',
+             `pager', `groff' or `plain'. With `auto', the format is `pager` or
+             `plain' whenever the TERM env var is `dumb' or undefined.
+  
+         --version
+             Show version information.
+  

--- a/test/groups.t
+++ b/test/groups.t
@@ -2,18 +2,20 @@
   listing things
 
   $ ./groups.exe things
-  Fatal error: exception File "src/cmdliner.ml", line 336, characters 42-48: Assertion failed
-  [2]
+  groups: this command has subcommands
+  Usage: groups COMMAND ...
+  Try `groups --help' for more information.
+  [124]
 
   $ ./groups.exe things show foo
   showing foo
 
   $ ./groups.exe things list --help
   NAME
-         groups-list
+         groups-things-list
   
   SYNOPSIS
-         groups list [OPTION]... 
+         groups things list [OPTION]... 
   
   OPTIONS
          --help[=FMT] (default=auto)
@@ -26,8 +28,10 @@
   
 
   $ ./groups.exe things --help
-  Fatal error: exception File "src/cmdliner.ml", line 336, characters 42-48: Assertion failed
-  [2]
+  groups: this command has subcommands
+  Usage: groups COMMAND ...
+  Try `groups --help' for more information.
+  [124]
 
   $ ./groups.exe --help
   NAME
@@ -38,6 +42,8 @@
   
   COMMANDS
          things
+  
+         widgets
   
   
   OPTIONS


### PR DESCRIPTION
This is my stab at #24. It seems to be feature complete with arbitrary command nesting, see `groups.t` for a demonstration.

I'm thinking of dropping the default choice at the top level of nesting for consistency with subcommands. That would match dune's behavior of `$ dune` summoning the main help page.