### PR TITLE
Term.exit and exit_status_of_result require a unit result

### DIFF
--- a/src/cmdliner.ml
+++ b/src/cmdliner.ml
@@ -276,14 +276,14 @@ module Term = struct
   (* Exits *)
 
   let exit_status_of_result ?(term_err = 1) = function
-  | `Ok _ | `Help | `Version -> exit_status_success
+  | `Ok () | `Help | `Version -> exit_status_success
   | `Error `Term -> term_err
   | `Error `Exn -> exit_status_internal_error
   | `Error `Parse -> exit_status_cli_error
 
   let exit_status_of_status_result ?term_err = function
   | `Ok n -> n
-  | r -> exit_status_of_result ?term_err r
+  | `Help | `Version | `Error _ as r -> exit_status_of_result ?term_err r
 
   let stdlib_exit = exit
   let exit ?term_err r = stdlib_exit (exit_status_of_result ?term_err r)

--- a/src/cmdliner.mli
+++ b/src/cmdliner.mli
@@ -434,11 +434,11 @@ module Term : sig
   (** [exit_status_internal_error] is 125, an exit status for unexpected
       internal errors. *)
 
-  val exit_status_of_result : ?term_err:int -> 'a result -> int
+  val exit_status_of_result : ?term_err:int -> unit result -> int
   (** [exit_status_of_result ~term_err r] is an [exit(3)] status
       code determined from [r] as follows:
       {ul
-      {- {!exit_status_success} if [r] is one of [`Ok _], [`Version], [`Help]}
+      {- {!exit_status_success} if [r] is one of [`Ok ()], [`Version], [`Help]}
       {- [term_err] if [r] is [`Error `Term], [term_err] defaults to [1].}
       {- {!exit_status_cli_error} if [r] is [`Error `Parse]}
       {- {!exit_status_internal_error} if [r] is [`Error `Exn]}} *)
@@ -447,7 +447,7 @@ module Term : sig
   (** [exit_status_of_status_result] is like {!exit_status_of_result}
       except for [`Ok n] where [n] is used as the status exit code. *)
 
-  val exit : ?term_err:int -> 'a result -> unit
+  val exit : ?term_err:int -> unit result -> unit
   (** [exit ~term_err r] is
       [Stdlib.exit @@ exit_status_of_result ~term_err r] *)
 


### PR DESCRIPTION
Previously, `exit` allowed passing any value to it and just ignored it. This leads to various errors going undetected. e.g. this program returns a successful exit status and displays no output, which is surprising:

```ocaml
let revolt () = Error (`Msg "Revolt!")
open Cmdliner
let revolt_t = Term.(const revolt $ const ())
let () = Term.exit @@ Term.eval (revolt_t, Term.info "revolt")
```

It also causes confusion when an argument is missing, e.g.

```ocaml
let chorus count msg =
  for i = 1 to count do print_endline msg done

open Cmdliner

let count =
  let doc = "Repeat the message $(docv) times." in
  Arg.(value & opt int 10 & info ["c"; "count"] ~docv:"COUNT" ~doc)

let chorus_t = Term.(const chorus $ count)

let () = Term.exit @@ Term.eval (chorus_t, Term.info "count")
```

This program compiled without error, but produces no output.

With this change, both programs report errors at compile-time.