### PR TITLE
Fix missing module implementation for Cmdliner_term_deprecated

### DIFF
--- a/src/cmdliner.mllib
+++ b/src/cmdliner.mllib
@@ -6,6 +6,7 @@ Cmdliner_docgen
 Cmdliner_msg
 Cmdliner_cline
 Cmdliner_arg
+Cmdliner_term_deprecated
 Cmdliner_term
 Cmdliner_cmd
 Cmdliner_eval


### PR DESCRIPTION
Just a simple fix for a missing module implementation error that I discovered while trying to update the version of cmdliner used in nixpkgs.  Here's the error I get when trying to build uuidm, for example:

```
ocamlfind ocamlopt -linkpkg -g -package cmdliner -package bytes -I src -I test src/uuidm.cmx test/uuidtrip.cmx -o test/uuidtrip.native
+ ocamlfind ocamlopt -linkpkg -g -package cmdliner -package bytes -I src -I test src/uuidm.cmx test/uuidtrip.cmx -o test/uuidtrip.native
File "_none_", line 1:
Error: No implementations provided for the following modules:
         Cmdliner_term_deprecated referenced from /nix/store/hd5n49fvwmhbxh9jyq9gjsj6d0qqhghm-ocaml4.13.1-cmdliner-1.1.1/lib/ocaml/4.13.1/site-lib/cmdliner/cmdliner.cmxa(Cmdliner)
Command exited with code 2.
pkg.ml: [ERROR] cmd ['ocamlbuild' '-use-ocamlfind' '-classic-display' '-j' '4' '-tag' 'debug'
     '-build-dir' '_build' 'opam' 'pkg/META' 'CHANGES.md' 'LICENSE.md'
     'README.md' 'src/uuidm.a' 'src/uuidm.cmxs' 'src/uuidm.cmxa'
     'src/uuidm.cma' 'src/uuidm.cmx' 'src/uuidm.cmi' 'src/uuidm.mli'
     'test/uuidtrip.native']: exited with 10
```