### PR TITLE
Write library artifacts to `%{lib}%/%{name}%` when using Nix

### DIFF
--- a/cmdliner.opam
+++ b/cmdliner.opam
@@ -11,8 +11,22 @@ license: ["ISC"]
 tags: ["cli" "system" "declarative" "org:erratique"]
 depends: ["ocaml" {>= "4.08.0"}]
 build: [[ make "all" "PREFIX=%{prefix}%" ]]
-install: [[make "install" "LIBDIR=%{_:lib}%" "DOCDIR=%{_:doc}%"]
-         [make "install-doc" "LIBDIR=%{_:lib}%" "DOCDIR=%{_:doc}%"]]
+install: [
+  [
+    make
+    "install"
+    "LIBDIR=%{_:lib}%" { os-distribution != "nixos"}
+    "LIBDIR=%{_:lib}%/%{name}%" { os-distribution = "nixos"}
+    "DOCDIR=%{_:doc}%"
+  ]
+  [
+    make
+    "install-doc"
+    "LIBDIR=%{_:lib}%" { os-distribution != "nixos"}
+    "LIBDIR=%{_:lib}%/%{name}%" { os-distribution = "nixos"}
+    "DOCDIR=%{_:doc}%"
+  ]
+]
 description: """
 Cmdliner allows the declarative definition of command line interfaces
 for OCaml.


### PR DESCRIPTION
I am currently writing a tool that lets you convert OPAM packages directly to Nix derivation and subsequently build them there without any intervention.

While doing that I noticed that `cmdliner` does not install its library artifacts into `%{lib}%/%{name}%`.
From what I can tell so far, most build/package systems follow that convention.

Unfortunately in a Nix setting we also rely on that convention for discoverability. 

If you agree with this change, I would also like to patch the opam files for older cmdliner versions in the [opam-repository](https://github.com/ocaml/opam-repository).