### PR TITLE
Fix unexpected-docstring warning when building with dune

### DIFF
--- a/src/cmdliner.mli
+++ b/src/cmdliner.mli
@@ -575,6 +575,7 @@ module Cmd : sig
     [@@@alert "-deprecated"]
     type info = Term.env_info (* because of Arg. *)
     (** The type for environment variable information. *)
+
     [@@@alert "+deprecated"]
 
     val info : ?deprecated:string -> ?docs:string -> ?doc:string -> var -> info
@@ -804,6 +805,7 @@ module Arg : sig
 
       {b Warning.} Do not use directly, use {!val-conv} or {!val-conv'}.
       This type will become abstract in the next major version of cmdliner. *)
+
   [@@@alert "+deprecated"] (* Need to be able to mention them ! *)
 
   val conv :


### PR DESCRIPTION
```
$ dune build
File "src/cmdliner.mli", line 577, characters 4-57:
577 |     (** The type for environment variable information. *)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error (warning 50 [unexpected-docstring]): ambiguous documentation comment
File "src/cmdliner.mli", lines 803-806, characters 2-78:
803 | ..(** The type for argument converters.
804 | 
805 |       {b Warning.} Do not use directly, use {!val-conv} or {!val-conv'}.
806 |       This type will become abstract in the next major version of cmdliner. *)
Error (warning 50 [unexpected-docstring]): ambiguous documentation comment
```
Tested with OCaml 4.14.0