### PR TITLE
Add Cmd.alias to create aliases of commands

### DIFF
--- a/src/cmdliner.mli
+++ b/src/cmdliner.mli
@@ -656,6 +656,9 @@ module Cmd : sig
   val name : 'a t -> string
   (** [name c] is the name of [c]. *)
 
+  val alias : info -> 'a t -> 'a t
+  (** [alias i cmd] creates an alias of [cmd] with information [i] *)
+
   (** {1:eval Evaluation}
 
       These functions are meant to be composed with {!Stdlib.exit}.

--- a/src/cmdliner_cmd.ml
+++ b/src/cmdliner_cmd.ml
@@ -29,6 +29,10 @@ let group ?default i cmds =
 
 let name c = Cmdliner_info.Cmd.name (get_info c)
 
+let alias i = function
+| Cmd (_, p) -> Cmd (i, p)
+| Group (_, grp) -> Group (i, grp)
+
 (*---------------------------------------------------------------------------
    Copyright (c) 2022 The cmdliner programmers
 

--- a/src/cmdliner_cmd.mli
+++ b/src/cmdliner_cmd.mli
@@ -22,6 +22,7 @@ val v : info -> 'a Cmdliner_term.t -> 'a t
 val group : ?default:'a Cmdliner_term.t -> info -> 'a t list -> 'a t
 val name : 'a t -> string
 val get_info : 'a t -> info
+val alias : info -> 'a t -> 'a t
 
 (*---------------------------------------------------------------------------
    Copyright (c) 2022 The cmdliner programmers


### PR DESCRIPTION
I'm currently trying to port opam to use the 1.1 API and this would be incredibly useful to have (otherwise we need to carry the old `(info, term)` tuple around like the old API and it's not really pretty)