### PR TITLE
Improve dune support

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -2,3 +2,4 @@
 S src
 S test
 B _b0/**
+B _build/**

--- a/test/dune
+++ b/test/dune
@@ -1,5 +1,11 @@
 (executables
- (names test_man
+ (names chorus
+        cp_ex
+        darcs_ex
+        revolt
+        rm_ex
+        tail_ex
+        test_man
         test_man_utf8
         test_pos
         test_nest


### PR DESCRIPTION
Configure merlin to exploit dune _build information
Configure dune to be able to build all examples in `test`