### PR TITLE
Use the same set of compiler options between dune and ocamlbuild

### DIFF
--- a/dune
+++ b/dune
@@ -1,0 +1,1 @@
+(env (_ (flags -bin-annot -safe-string))) ; Use the same flags as with ocamlbuild

--- a/src/dune
+++ b/src/dune
@@ -1,4 +1,3 @@
 (library
  (public_name cmdliner)
- (flags :standard -w -3-6-27-32-35)
  (wrapped false))


### PR DESCRIPTION
As directed in https://github.com/dbuenzli/cmdliner/pull/159#issuecomment-1352973481