### PR TITLE
Manpage plain `I: add newline always

### DIFF
--- a/src/cmdliner_manpage.ml
+++ b/src/cmdliner_manpage.ml
@@ -331,12 +331,11 @@ let pp_plain_blocks ~errs subst ppf ts =
           let ll = String.length label in
           begin match ll < l_indent with
           | true ->
-              pf ppf "%a@[%a@]@]" pp_indent (l_indent - ll) pp_tokens s
+              pf ppf "%a@[%a@]@]@," pp_indent (l_indent - ll) pp_tokens s
           | false ->
-              pf ppf "@\n%a@[%a@]@]"
+              pf ppf "@\n%a@[%a@]@]@,"
                 pp_indent (p_indent + l_indent) pp_tokens s
           end;
-          match ts with `I _ :: _ -> pf ppf "@," | _ -> ()
       end;
       begin match ts with
       | `Noblank :: ts -> loop ts


### PR DESCRIPTION
A series of `` `I _; `Noblank; ...`` gets rendered oddly with the plain output:

```
DESCRIPTION
       The describe command describes the configuration of a mirage
       application.

       The dot output contains the following elements:
       If vertices
           Represented as circles. Branches are dotted, and the default
           branch is in bold.       Configurables
                                        Represented as rectangles. The order
                                        of the output arrows is the order of
                                        the functor arguments.       
                                                              Data
                                                              dependencies
                                                                         
                                                              Represented as
                                                              dashed arrows.
       App vertices
           Represented as diamonds. The bold arrow is the functor part.
```

This adds a cut at the end of the text always.