### PR TITLE
Add --help=commands

### DIFF
--- a/src/cmdliner_arg.ml
+++ b/src/cmdliner_arg.ml
@@ -317,26 +317,35 @@ let man_fmts =
   ["auto", `Auto; "pager", `Pager; "groff", `Groff; "plain", `Plain]
 
 let man_fmt_docv = "FMT"
-let man_fmts_enum = Cmdliner_base.enum man_fmts
-let man_fmts_alts = doc_alts_enum man_fmts
-let man_fmts_doc kind =
-  strf "Show %s in format $(docv). The value $(docv) must be %s. \
-        With $(b,auto), the format is $(b,pager) or $(b,plain) whenever \
-        the $(b,TERM) env var is $(b,dumb) or undefined."
-    kind man_fmts_alts
+
+let mk_man_format man_fmts doc_kind =
+  let man_fmts_enum = Cmdliner_base.enum man_fmts in
+  let man_fmts_alts = doc_alts_enum man_fmts in
+  let man_fmts_doc =
+    strf
+      "Show %s in format $(docv). The value $(docv) must be %s. With \
+       $(b,auto), the format is $(b,pager) or $(b,plain) whenever the \
+       $(b,TERM) env var is $(b,dumb) or undefined. With $(b,commands), \
+       outputs the list of commands, separated by newlines."
+      doc_kind man_fmts_alts
+  in
+  (man_fmts_enum, man_fmts_doc)
 
 let man_format =
-  let doc = man_fmts_doc "output" in
+  let arg, doc = mk_man_format man_fmts "output" in
   let docv = man_fmt_docv in
-  value & opt man_fmts_enum `Pager & info ["man-format"] ~docv ~doc
+  value & opt arg `Pager & info ["man-format"] ~docv ~doc
 
 let stdopt_version ~docs =
   value & flag & info ["version"] ~docs ~doc:"Show version information."
 
+type help_format = [ `Commands | Cmdliner_manpage.format ]
+
 let stdopt_help ~docs =
-  let doc = man_fmts_doc "this help" in
+  let help_fmts = man_fmts @ [ "commands", `Commands ] in
+  let arg, doc = mk_man_format help_fmts "this help" in
   let docv = man_fmt_docv in
-  value & opt ~vopt:(Some `Auto) (some man_fmts_enum) None &
+  value & opt ~vopt:(Some `Auto) (some arg) None &
   info ["help"] ~docv ~docs ~doc
 
 (* Predefined converters. *)

--- a/src/cmdliner_arg.mli
+++ b/src/cmdliner_arg.mli
@@ -62,9 +62,11 @@ val last : 'a list t -> 'a Cmdliner_term.t
 
 (** {1 Predefined arguments} *)
 
+type help_format = [ `Commands | Cmdliner_manpage.format ]
+
 val man_format : Cmdliner_manpage.format Cmdliner_term.t
 val stdopt_version : docs:string -> bool Cmdliner_term.t
-val stdopt_help : docs:string -> Cmdliner_manpage.format option Cmdliner_term.t
+val stdopt_help : docs:string -> help_format option Cmdliner_term.t
 
 (** {1 Converters} *)
 

--- a/src/cmdliner_msg.ml
+++ b/src/cmdliner_msg.ml
@@ -96,6 +96,19 @@ let pp_err_usage ppf ei ~err_lines ~err =
     (exec_name ei) pp_err err (Cmdliner_docgen.pp_plain_synopsis ~errs:ppf) ei
     pp_try_help ei
 
+let pp_commands ppf ei =
+  let open Cmdliner_info in
+  let rec find_sub_commands path cmd =
+    let path = Cmd.name cmd :: path in
+    List.rev path :: List.concat_map (find_sub_commands path) (Cmd.children cmd)
+  in
+  let pp_segs =
+    let pp_sep ppf () = pp ppf " " in
+    Format.(pp_print_list ~pp_sep pp_print_string)
+  in
+  find_sub_commands [] (Eval.main ei)
+  |> List.iter (pp ppf "%a@." pp_segs)
+
 let pp_backtrace ppf ei e bt =
   let bt = Printexc.raw_backtrace_to_string bt in
   let bt =

--- a/src/cmdliner_msg.mli
+++ b/src/cmdliner_msg.mli
@@ -35,6 +35,9 @@ val pp_err : Format.formatter -> Cmdliner_info.Eval.t -> err:string -> unit
 val pp_err_usage :
   Format.formatter -> Cmdliner_info.Eval.t -> err_lines:bool -> err:string -> unit
 
+(** The output of [--help=commands]. *)
+val pp_commands : Format.formatter -> Cmdliner_info.Eval.t -> unit
+
 val pp_backtrace :
   Format.formatter ->
   Cmdliner_info.Eval.t -> exn -> Printexc.raw_backtrace -> unit


### PR DESCRIPTION
This adds `--help=commands`, which prints the list of all the sub-commands accepted by the executable.
This list can be used to quickly navigate between the different manpages and can be parsed.

The output on `test/darcs_ex` is:

    darcs
    darcs initialize
    darcs record
    darcs help

Unlike other help formats, it outputs to stdout and use a strict format that can be parsed: newline-separated list.

This is an argument to the `--help` option instead of a new option because it can also be used by humans.
It is not exposed in the library.

The main motivation is to be able to generate odoc pages containing the manpage of each commands. I've tried this in the past for Odoc (https://github.com/ocaml/odoc/pull/903) and I'm considering this for ocamlformat.
What do you think of this ?