### PR TITLE
Allow mixing opt_all and vflag_all

### DIFF
--- a/src/cmdliner_arg.mli
+++ b/src/cmdliner_arg.mli
@@ -8,6 +8,8 @@
 (* Converters *)
 
 type 'a conv
+type 'a econv = Conv : { conv : 'b conv; vopt : 'b option; vconv : ('b -> 'a)} -> 'a econv
+type 'a opt_or_vflag_arg = Opt of 'a econv | VFlag of 'a
 
 module Completion : sig
   type complete = string -> (string * string) list
@@ -58,6 +60,7 @@ val vflag : 'a -> ('a * info) list -> 'a t
 val vflag_all : 'a list -> ('a * info) list -> 'a list t
 val opt : ?vopt:'a -> 'a conv -> 'a -> info -> 'a t
 val opt_all : ?vopt:'a -> 'a conv -> 'a list -> info -> 'a list t
+val opt_vflag_all : 'a list -> ('a opt_or_vflag_arg * info) list -> 'a list t
 
 val pos : ?rev:bool -> int -> 'a conv -> 'a -> info -> 'a t
 val pos_all : 'a conv -> 'a list -> info -> 'a list t

--- a/test/example_mixed_args.ml
+++ b/test/example_mixed_args.ml
@@ -1,0 +1,45 @@
+open Cmdliner
+
+type mood =
+| Panic
+| Chill
+| Beverage of string
+| Nap of int
+
+let mk_opt_arg ~conv ~vopt ~vconv = Arg.Opt (Conv { conv; vopt; vconv })
+
+let options =
+  let beverage =
+    mk_opt_arg ~conv:Arg.string ~vopt:(Some "coffee") ~vconv:(fun s -> Beverage s)
+  in
+  let nap =
+    mk_opt_arg ~conv:Arg.int ~vopt:(Some 15) ~vconv:(fun i -> Nap i)
+  in
+  let args =
+    Arg.
+      [ VFlag Panic, info [ "p"; "panic" ] ~doc:"Panic mode. Not recommended."
+      ; VFlag Chill, info [ "c"; "chill" ] ~doc:"Chill mode. Highly recommended."
+      ; beverage, info [ "b"; "beverage" ] ~doc:"Pick a drink (default: coffee)."
+      ; nap, info [ "n"; "nap" ] ~doc:"Nap time in minutes (default: 15)."
+      ]
+  in
+  Arg.(value & opt_vflag_all [] args)
+
+let run moods =
+  let msg =
+    List.map (function
+      | Panic -> "PANIC!!!"
+      | Chill -> "Everything's fine."
+      | Beverage b -> "Drinking " ^ b
+      | Nap t -> "Nap for " ^ string_of_int t ^ " min.")
+      moods
+    |> String.concat " | "
+  in
+  Printf.printf "%s\n" msg;
+  Ok ()
+
+let cmd =
+  let term = Term.(term_result (const run $ options)) in
+  Cmd.v (Cmd.info "moodctl" ~version:"1.0") term
+
+let () = exit (Cmd.eval cmd)


### PR DESCRIPTION
Hi, 

Currently, we can define multiple `vflags` with `vflag_all` which returns a list
> that contains one corresponding value per occurrence of the flag, in the order found on the command line. 

This PR extends that functionality by allowing `opt_all` and `vflag_all` to be mixed within the same definition.

The new `opt_vflag_all` function returns a list that contains one corresponding value per occurrence of _the flag or the option_, in the order found on the command line. A GADT is used to convert option values (which may have different types) and unify them with the flag values. 

The goal is to provide users with greater flexibility when defining a logic where the order of applying flags and options matter.

Started from https://github.com/ocaml/opam/issues/6387 
