### PR TITLE
Fix opam+Dune completions install instructions

### DIFF
--- a/doc/cookbook.mld
+++ b/doc/cookbook.mld
@@ -227,8 +227,8 @@ build: [
    [ … ] # Your regular dune build instructions
    ["cmdliner" "install" "tool-support"
                "--update-opam-install=%{_:name}%.install"
-               "_build/install/default/bin/tool" {os != "win32"}
-               "_build/install/default/bin/tool.exe" {os = "win32"}
+               "_build/install/default/bin/tool" {os-family != "windows"}
+               "_build/install/default/bin/tool.exe" {os-family = "windows"}
                "_build/cmdliner-install"]]
 ]}
 


### PR DESCRIPTION
`_build/default/` is where the source and build artifacts are, `_build/install/default` is the default installation destination directory.

The installation instructions are wrong on Cygwin which also uses the `.exe` extension. From [opam's manual > Global variables](https://opam.ocaml.org/doc/Manual.html#Global-variables):

> `os`: the running OS, typically one of `"linux"`, `"macos"`, `"win32"`, `"cygwin"`, `"freebsd"`, `"openbsd"`, `"netbsd"` or `"dragonfly"`, or the lowercased output of `uname -s`, or `"unknown"`  
> `os-family`: the more general distribution family, e.g. `"debian"` on Ubuntu, `"windows"` on Win32 or Cygwin, `"bsd"` on all bsds. Useful e.g. to detect the main package manager