### PR TITLE
bash completion: tell completion system when we are using filenames

### DIFF
--- a/src/tool/bash-completion.sh
+++ b/src/tool/bash-completion.sh
@@ -15,10 +15,12 @@ _cmdliner_generic() {
         read group
       elif [[ $type == "dirs" ]] && (type compopt &> /dev/null); then
         if [[ $prefix != -* ]]; then
+          compopt -o filenames
           COMPREPLY+=( $(compgen -d "$prefix") )
         fi
       elif [[ $type == "files" ]] && (type compopt &> /dev/null); then
         if [[ $prefix != -* ]]; then
+          compopt -o filenames
           COMPREPLY+=( $(compgen -f "$prefix") )
         fi
       elif [[ $type == "message" ]]; then


### PR DESCRIPTION
Closes #238 

With this, tab-completions for files end with a / and no space, allowing easier completion-chaining