### PR TITLE
Support file and directory completions immediately following an option

### DIFF
--- a/src/tool/bash-completion.sh
+++ b/src/tool/bash-completion.sh
@@ -17,7 +17,7 @@ _cmdliner_generic() {
     while read type; do
       if [[ $type == "group" ]]; then
         read group
-      elif [[ $type == "dirs" ]] && (type compopt &> /dev/null); then
+      elif [[ $type == "dirs" || $type == "files" ]] && (type compopt &> /dev/null); then
         # trim option prefix in cases like --file=<TAB> or -f<TAB>
         local pattern="$prefix"
         local reply_prefix=""
@@ -28,25 +28,14 @@ _cmdliner_generic() {
           reply_prefix="${prefix:0:2}"
         fi
 
+        # enable filename completion features like trailing slash for dirs
         compopt -o filenames -o nospace
-        local dirs=( $(compgen -d "$pattern") )
-        for d in "${dirs[@]}"; do
-          COMPREPLY+=("${reply_prefix}${d}")
-        done
-       elif [[ $type == "files" ]] && (type compopt &> /dev/null); then
-        local pattern="$prefix"
-        local reply_prefix=""
-        if [[ $pattern == --* ]]; then
-          pattern="${prefix#*=}"
-        elif [[ $pattern == -* ]]; then
-          pattern="${prefix:2}"
-          reply_prefix="${prefix:0:2}"
-        fi
 
-        compopt -o filenames -o nospace
-        local dirs=( $(compgen -f "$pattern") )
-        for d in "${dirs[@]}"; do
-          COMPREPLY+=("${reply_prefix}${d}")
+        # need to run compgen with -d or -f flag
+        local flag="${type:0:1}"
+        local completions=( $(compgen -$flag "$pattern") )
+        for c in "${completions[@]}"; do
+          COMPREPLY+=("${reply_prefix}${c}")
         done
       elif [[ $type == "message" ]]; then
           msg="";

--- a/src/tool/cmdliner_data.ml
+++ b/src/tool/cmdliner_data.ml
@@ -18,7 +18,7 @@ let bash_generic_completion =
     while read type; do
       if [[ $type == "group" ]]; then
         read group
-      elif [[ $type == "dirs" ]] && (type compopt &> /dev/null); then
+      elif [[ $type == "dirs" || $type == "files" ]] && (type compopt &> /dev/null); then
         # trim option prefix in cases like --file=<TAB> or -f<TAB>
         local pattern="$prefix"
         local reply_prefix=""
@@ -29,25 +29,14 @@ let bash_generic_completion =
           reply_prefix="${prefix:0:2}"
         fi
 
+        # enable filename completion features like trailing slash for dirs
         compopt -o filenames -o nospace
-        local dirs=( $(compgen -d "$pattern") )
-        for d in "${dirs[@]}"; do
-          COMPREPLY+=("${reply_prefix}${d}")
-        done
-       elif [[ $type == "files" ]] && (type compopt &> /dev/null); then
-        local pattern="$prefix"
-        local reply_prefix=""
-        if [[ $pattern == --* ]]; then
-          pattern="${prefix#*=}"
-        elif [[ $pattern == -* ]]; then
-          pattern="${prefix:2}"
-          reply_prefix="${prefix:0:2}"
-        fi
 
-        compopt -o filenames -o nospace
-        local dirs=( $(compgen -f "$pattern") )
-        for d in "${dirs[@]}"; do
-          COMPREPLY+=("${reply_prefix}${d}")
+        # need to run compgen with -d or -f flag
+        local flag="${type:0:1}"
+        local completions=( $(compgen -$flag "$pattern") )
+        for c in "${completions[@]}"; do
+          COMPREPLY+=("${reply_prefix}${c}")
         done
       elif [[ $type == "message" ]]; then
           msg="";


### PR DESCRIPTION
This closes #231 (addresses bullet 2).

You can now do `test_shell --file=<TAB>` and get suggestions. Short options like `-ds<TAB>` also work, although it looks adding back the `-d` we need breaks the feature that ends the completion with `/` for directories, which is a shame (so the previous completes to `-dsrc` in this repo, for example).
