### PR TITLE
pwsh: quote completion reply when necessary

### DIFF
--- a/src/tool/cmdliner_data.ml
+++ b/src/tool/cmdliner_data.ml
@@ -180,7 +180,8 @@ $Global:%s = {
     if ($otherArgs -ne "") {
       $otherArgs += " "
     }
-    if ($text -eq $wordToComplete) {
+    # wordToComplete has had quoting removed, so we need to remove it before comparison
+    if ($text -replace "[`"']", "" -eq $wordToComplete) {
       $otherArgs += "--__complete=$text"
       $seenWordToComplete = $true
     }
@@ -251,8 +252,8 @@ $Global:%s = {
         $completionItem = $item
 
         if ($group -eq "Values") {
-          # quote replies with commas, since powershell considers those separators
-          if ($completionItem -match ',') {
+          # quote replies with powershell separators
+          if ($completionItem -match "[,|;]") {
             $completionItem = '"' + $completionItem + '"'
           }
           # re-add prefix for things like --foo=

--- a/src/tool/pwsh-completion.ps1
+++ b/src/tool/pwsh-completion.ps1
@@ -21,7 +21,8 @@ $Global:_cmdliner_generic = {
     if ($otherArgs -ne "") {
       $otherArgs += " "
     }
-    if ($text -eq $wordToComplete) {
+    # wordToComplete has had quoting removed, so we need to remove it before comparison
+    if ($text -replace "[`"']", "" -eq $wordToComplete) {
       $otherArgs += "--__complete=$text"
       $seenWordToComplete = $true
     }
@@ -92,8 +93,8 @@ $Global:_cmdliner_generic = {
         $completionItem = $item
 
         if ($group -eq "Values") {
-          # quote replies with commas, since powershell considers those separators
-          if ($completionItem -match ',') {
+          # quote replies with powershell separators
+          if ($completionItem -match "[,|;]") {
             $completionItem = '"' + $completionItem + '"'
           }
           # re-add prefix for things like --foo=


### PR DESCRIPTION
When testing my [list completer function](https://github.com/dbuenzli/cmdliner/issues/239#issuecomment-3542936104) I discovered that powershell requires you to quote strings with commas in them if you want them treated as one value, so you'd write something like `mytool --foo="bar,b<TAB>"`, and the reply needs to be quoted as well. 

I suspect there will be more values than just `,` that will need to be tested for in replies, but this is a start.