### PR TITLE
Add `.NOTPARALLEL` directive to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,3 +134,4 @@ install-completions:
 	build-native-dynlink build-byte-exe build-native-exe build-completions \
 	prepare-prefix install-common install-byte install-native install-dynlink \
 	install-exe install-completions build-man
+.NOTPARALLEL:


### PR DESCRIPTION
If `make` is invoked with its `-j` option, given through the command line or with the `MAKEFLAGS` environment variable, it will build the recipes in parallel. The cmdliner build system doesn't support parallel execution and is prone to races (for instance, there's a TOCTOU in `mkdir`).

The `.NOTPARALLEL` directive of Make disables parallel execution. The GNU Make version shipped in macOS doesn't support `.WAIT`, so for compatibility rely on this all-in-one variable.

https://www.gnu.org/software/make/manual/html_node/Parallel-Disable.html

Note that the `-j` option of Make isn't used in the opam file, where `-j%{jobs}` could have been passed.

```console
$ make all -j4
ocaml build.ml cma
ocaml build.ml cmxa
ocaml build.ml cmxs
mkdir: cannot create directory ‘C:\\Users\\misterda\\Tarides\\cmdliner\\_build’: File exists
exited with 1: "mkdir" "C:\Users\misterda\Tarides\cmdliner\_build"
mkdir: cannot create directory ‘C:\\Users\\misterda\\Tarides\\cmdliner\\_build’: File exists
make: *** [Makefile:63: build-native] Error 1
exited with 1: "mkdir" "C:\Users\misterda\Tarides\cmdliner\_build"
make: *** Waiting for unfinished jobs....
make: *** [Makefile:66: build-native-dynlink] Error 1
```