### PR TITLE
Add `.exe` extension to cmdliner tool on Windows

### DIFF
--- a/build.ml
+++ b/build.ml
@@ -142,11 +142,15 @@ let exe ar src =
   let lib = build_dir Lib in
   ["-I"; lib; ar] @ common src
 
+let host_exe_ext = if Sys.win32 || Sys.cygwin then ".exe" else ""
+
+let cmdliner_exe = "cmdliner" ^ host_exe_ext
+
 let build_natexe srcs =
-  run_cmd ([ocamlopt ()] @ exe "cmdliner.cmxa" srcs @ ["-o"; "cmdliner"])
+  run_cmd ([ocamlopt ()] @ exe "cmdliner.cmxa" srcs @ ["-o"; cmdliner_exe])
 
 let build_bytexe srcs =
-  run_cmd ([ocamlc ()] @ exe "cmdliner.cma" srcs @ ["-o"; "cmdliner"])
+  run_cmd ([ocamlc ()] @ exe "cmdliner.cma" srcs @ ["-o"; cmdliner_exe])
 
 let build_cma srcs =
   run_cmd ([ocamlc ()] @ common srcs @ ["-a"; "-o"; "cmdliner.cma"])


### PR DESCRIPTION
This fixes new build failures reported in #233:

cmdliner.2.0.0:

```
ocaml build.ml cma
ocaml build.ml cmxa
ocaml build.ml natexe
_build/src/tool/cmdliner generic-completion bash > _build/src/tool/bash-completion.sh
_build/src/tool/cmdliner tool-completion bash cmdliner > _build/src/tool/bash-cmdliner.sh
_build/src/tool/cmdliner generic-completion zsh > _build/src/tool/zsh-completion.sh
_build/src/tool/cmdliner tool-completion zsh cmdliner > _build/src/tool/zsh-cmdliner.sh
_build/src/tool/cmdliner install tool-manpages _build/src/tool/cmdliner _build/src/tool/man
'"_build\src\tool\cmdliner"' is not recognized as an internal or external command,
operable program or batch file.
""_build\src\tool\cmdliner" "--__complete" "--__complete=" > "C:\Users\misterda\AppData\Local\opam\.cygwin\root\tmp\cmd9740adstdout"": exited with 1
make: *** [Makefile:80: build-man] Error 123
```

cmdliner.2.1.0:

```
ocaml build.ml cma
ocaml build.ml cmxa
ocaml build.ml natexe
_build/src/tool/cmdliner generic-completion bash > _build/src/tool/bash-completion.sh
_build/src/tool/cmdliner tool-completion bash cmdliner > _build/src/tool/bash-cmdliner.sh
_build/src/tool/cmdliner generic-completion zsh > _build/src/tool/zsh-completion.sh
_build/src/tool/cmdliner tool-completion zsh cmdliner > _build/src/tool/zsh-cmdliner.sh
_build/src/tool/cmdliner generic-completion pwsh > _build/src/tool/pwsh-completion.ps1
_build/src/tool/cmdliner tool-completion pwsh cmdliner > _build/src/tool/pwsh-cmdliner.ps1
_build/src/tool/cmdliner install tool-manpages _build/src/tool/cmdliner _build/src/tool/man
'"_build\src\tool\cmdliner"' is not recognized as an internal or external command,
operable program or batch file.
""_build\src\tool\cmdliner" "--__complete" "--__complete=" > "C:\Users\misterda\AppData\Local\opam\.cygwin\root\tmp\cmd735a8astdout"": exited with 1
make: *** [Makefile:83: build-man] Error 123
```

I would enjoy a patch release with this fix.