### PR TITLE
Enable ocamlfind lookup of executables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ prepare-prefix:
 
 install-common: prepare-prefix
 	$(INSTALL) -m 644 pkg/META $(BASE).cmi "$(LIBDIR)"
-	$(INSTALL) -m 644 cmdliner.opam "$(LIBDIR)/opam"
+	$(INSTALL) -m 644 opam "$(LIBDIR)/opam"
 
 install-srcs: prepare-prefix
 	$(INSTALL) -m 644 $(wildcard $(BASE)*.mli) $(wildcard $(BASE)*.ml) \

--- a/build.ml
+++ b/build.ml
@@ -121,16 +121,16 @@ let rec rmdir dir =
 
 let really_find_cmd alts =
   match Sys.getenv_opt "OCAMLFIND_TOOLCHAIN" with
+  | None | Some "" -> (
+      match find_cmd alts with
+      | Some cmd -> [cmd]
+      | None -> err "No %s found in PATH\n" (List.hd @@ List.rev alts))
   | Some toolchain -> (
       match find_cmd [ "ocamlfind" ] with
       | Some ocamlfind ->
         [ocamlfind; "-toolchain"; toolchain; List.hd @@ List.rev alts]
       | None ->
           err "OCAMLFIND_TOOLCHAIN is set but ocamlfind not found in PATH\n")
-  | None -> (
-      match find_cmd alts with
-      | Some cmd -> [cmd]
-      | None -> err "No %s found in PATH\n" (List.hd @@ List.rev alts))
 
 let ocamlc () = really_find_cmd ["ocamlc.opt"; "ocamlc"]
 let ocamlopt () = really_find_cmd ["ocamlopt.opt"; "ocamlopt"]


### PR DESCRIPTION
Closes #259 

For something like opam-cross-windows, the following is now sufficient:

```
make build-byte build-native build-native-exe OCAMLFIND_TOOLCHAIN=windows
```

I didn't do all the makefile work necessary to have `build-completions` work, as this requires a host copy of the cmdliner tool, which would mean detecting when cross compilation is happening and building it twice. It's possible, but it doesn't seem that valuable; `opam-cross-windows` is for building binaries for end users, so the completions etc would be provided separately and likely with `--standalone-completions`