### PR TITLE
Use older, deprecated name _command_offset in bash completion

### DIFF
--- a/src/tool/bash-completion.sh
+++ b/src/tool/bash-completion.sh
@@ -68,7 +68,7 @@ _cmdliner_generic() {
           # N.B. only emitted if there is a -- token
           for ((i = 0; i < ${#words[@]}; i++)); do
               if [[ "${words[i]}" == "--" ]]; then
-                  _comp_command_offset $((i+1))
+                  _command_offset $((i+1))
                   return
               fi
           done

--- a/src/tool/cmdliner_data.ml
+++ b/src/tool/cmdliner_data.ml
@@ -71,7 +71,7 @@ let bash_generic_completion fun_name = strf
           # N.B. only emitted if there is a -- token
           for ((i = 0; i < ${#words[@]}; i++)); do
               if [[ "${words[i]}" == "--" ]]; then
-                  _comp_command_offset $((i+1))
+                  _command_offset $((i+1))
                   return
               fi
           done


### PR DESCRIPTION
The `_comp_command_offset` name is only available in bash-completion 2.12, which is newer than the one shipped on Ubuntu LTS. The old name, `_command_offset`, [is still aliased](https://github.com/scop/bash-completion/blob/f817ccabe8db631b96d4b84784bb0109339eebae/bash_completion.d/000_bash_completion_compat.bash#L7). 

Using it grants the ability to use the reset token on older bash installations, and should just be the same as the existing code on newer ones. 

Note that `_get_comp_words_by_ref`, the other bash-completion function used, is already using [the pre-2.12 name](https://github.com/scop/bash-completion/blob/f817ccabe8db631b96d4b84784bb0109339eebae/bash_completion.d/000_bash_completion_compat.bash#L12)