### PR TITLE
Fix typos

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -104,7 +104,7 @@ v2.0.0 2025-09-26 Zagreb
 - Make `--help` request work in any context, except after `--` or on
   the arguments after an unknown command error in which case that
   error is reported (less confusing). Since the option has an optional
-  argument value, one had to be carefull that it would not pickup the
+  argument value, one had to be careful that it would not pickup the
   next argument and try to parse it according to `FMT`. This is no
   longer the case. If the argument fails to parse `--help=auto` is
   assumed. (#201).
@@ -116,7 +116,7 @@ v2.0.0 2025-09-26 Zagreb
 - Reserve the `--__complete` option for library use.
 
 - Documentation language, `$(cmd)`, `$(cmd.name)` and `$(tool)` can be
-  used and should be prefered over of `$(iname)`, `$(tname)` and
+  used and should be preferred over of `$(iname)`, `$(tname)` and
   `$(mname)`. `$(cmd.parent)` is added to refer to a command's parent
   or itself at the root.
 
@@ -146,7 +146,7 @@ v2.0.0 2025-09-26 Zagreb
 - Add `Arg.Conv` module to define converters. This should be used in
   new code. 
 
-- Add `Arg.{file,dir,}path` string converters equiped with appropriate
+- Add `Arg.{file,dir,}path` string converters equipped with appropriate
   file system completions.
 
 - Add `docv` optional parameter to `Arg.enum`.
@@ -407,7 +407,7 @@ v1.0.1 2017-08-03 Zagreb
 ------------------------
 
 - Add a `Makefile` to build and install cmdliner without `topkg` and
-  opam `.install` files. Helps bootstraping opam in OS package
+  opam `.install` files. Helps bootstrapping opam in OS package
   managers. Thanks to Hendrik Tews for the patches.
 
 v1.0.0 2017-03-02 La Forclaz (VS)

--- a/DEVEL.md
+++ b/DEVEL.md
@@ -45,7 +45,7 @@ by `git`).
 
 The [`B0.ml`](B0.ml) file of cmdliner includes `test/b0/B0.ml` and the
 `default` pack of `B0.ml` is unlocked so that when a test executable
-requires `b0.std` it is looked up and built againt the development
+requires `b0.std` it is looked up and built against the development
 version of cmdliner. After that testing remains [as usual].
 
 [as usual]: https://erratique.ch/software/b0/doc/occasionally.html#test

--- a/doc/cli.mld
+++ b/doc/cli.mld
@@ -407,7 +407,7 @@ protocol is versioned but can change even between minor versions of
 Cmdliner. Generic scripts for popular shells can be inspected via
 the [cmdliner generic-completion] command.
 
-The protocol betwen the shell completion {e script} and a
+The protocol between the shell completion {e script} and a
 cmdliner based {e tool} is as follows:
 
 {ol
@@ -477,7 +477,7 @@ The semantics of directives is as follows:
    directories starting with [ARG] to completion values.}
 {- A [restart] directive indicates that the script should restart
    shell completion as if the command line was starting after the leftmost
-   [--] disambiguation token. The directive never gets emited if
+   [--] disambiguation token. The directive never gets emitted if
    there is no [--] on the command line.}}
 
 You can easily inspect the completions of any cmdliner based tool by

--- a/doc/cookbook.mld
+++ b/doc/cookbook.mld
@@ -343,7 +343,7 @@ let write_file file s =
 
 Cmdliner has support to back values defined by arguments with
 environment variables. The value specified via an environment variable
-should never take over an argument specified explicitely on the
+should never take over an argument specified explicitly on the
 command line. The environment variable should be seen as providing
 the default value when the argument is absent.
 
@@ -384,7 +384,7 @@ let loud =
   Arg.(value & flag & info ["l"; "loud"] ~doc)
 ]}
 
-The following defines the [-m] and [--message] options. The term [msg] evalutes
+The following defines the [-m] and [--message] options. The term [msg] evaluates
 to ["Revolt!"] when the option is absent on the command line.
 {[
 let msg =

--- a/src/cmdliner.mli
+++ b/src/cmdliner.mli
@@ -281,7 +281,7 @@ end
 
 (** Commands.
 
-    Command line syntaxes are implicitely defined by {!Term.t}
+    Command line syntaxes are implicitly defined by {!Term.t}
     values. A command value binds a term and its documentation to a
     command name.
 
@@ -384,7 +384,7 @@ module Cmd : sig
         {- [deprecated], if specified the environment variable is
            deprecated.  Use of the variable warns on dep[stderr] This
            message which should be a capitalized sentence is
-           preprended to [doc] and output on standard error when the
+           prepended to [doc] and output on standard error when the
            environment variable ends up being used.}}
 
         In [doc] and [deprecated] the {{!page-tool_man.doclang}documentation
@@ -417,7 +417,7 @@ module Cmd : sig
       {- [deprecated], if specified the command is deprecated. Use of the
           variable warns on [stderr]. This
           message which should be a capitalized sentence is
-          preprended to [doc] and output on standard error when the
+          prepended to [doc] and output on standard error when the
           environment variable ends up being used.}
       {- [doc] is a one line description of the command used
          for the [NAME] section of the command's man page and in command
@@ -447,7 +447,7 @@ module Cmd : sig
       {- [$(cmd.name)] the command's name.}
       {- [$(cmd.parent)] the command's parent or the main command if none.}}
 
-      Previously some of these names were refered to as [$(tname)],
+      Previously some of these names were referred to as [$(tname)],
       [$(mname)] and [$(iname)], they still work but do not use them,
       they are obscure. *)
 
@@ -563,7 +563,7 @@ module Cmd : sig
       {- [help] is the formatter used to print help, version messages
          or completions, (defaults to {!Format.std_formatter}). Note
          that the completion protocol needs to output ['\n'] line ending,
-         if you are outputing to a channel make sure it is in binary
+         if you are outputting to a channel make sure it is in binary
          mode to avoid newline translation (this is done automatically
          before completion when [help] is {!Format.std_formatter}).}
       {- [err] is the formatter used to print error messages
@@ -676,10 +676,10 @@ module Arg : sig
         tools like [sudo -- TOOL [ARG]…]. For the latter a restart
         completion should be added on all positional arguments.  If
         you allow [TOOL] to be only a restricted set of tools known to
-        your program you'd eschew [restart] on the first postional
+        your program you'd eschew [restart] on the first positional
         argument but add it to the remaining ones.
 
-        {b Warning.} A [restart] directive is eventually emited only
+        {b Warning.} A [restart] directive is eventually emitted only
         if the completion is requested after a [--] token. In this
         case other completions returned alongside by {!func} are
         ignored. Educate your users to use the [--], for example
@@ -730,7 +730,7 @@ module Arg : sig
     val make : ?context:'ctx Term.t -> ('ctx, 'a) func -> 'a t
     (** [make ~context func] uses [func] to complete.
 
-        [context] defines a commmand line fragment that is evaluated
+        [context] defines a command line fragment that is evaluated
         before performing the completion. It the evaluation is
         successful the result is given to the completion
         function. Otherwise [None] is given.
@@ -793,8 +793,8 @@ module Arg : sig
 
     val docv : 'a t -> string
     (** [docv c] is [c]'s documentation meta-variable. This value can
-        be refered to as [$(docv)] in the documentation strings of
-        arguments.  It can be overriden by the {!val-info} value of an
+        be referred to as [$(docv)] in the documentation strings of
+        arguments.  It can be overridden by the {!val-info} value of an
         argument. *)
 
     val parser : 'a t -> 'a parser
@@ -871,7 +871,7 @@ module Arg : sig
       {- [deprecated], if specified the argument is deprecated. Use of the
           variable warns on [stderr]. This
           message which should be a capitalized sentence is
-          preprended to [doc] and output on standard error when the
+          prepended to [doc] and output on standard error when the
           environment variable ends up being used.}
       {- [absent], if specified a documentation string that indicates
          what happens when the argument is absent. The document language

--- a/src/cmdliner_arg.mli
+++ b/src/cmdliner_arg.mli
@@ -96,7 +96,7 @@ val man_format : Cmdliner_manpage.format Cmdliner_term.t
 val stdopt_version : docs:string -> bool Cmdliner_term.t
 val stdopt_help : docs:string -> Cmdliner_manpage.format option Cmdliner_term.t
 
-(* Predifined converters *)
+(* Predefined converters *)
 
 val bool : bool conv
 val char : char conv

--- a/src/tool/cmdliner_data.ml
+++ b/src/tool/cmdliner_data.ml
@@ -361,7 +361,7 @@ $Global:%s = {
     return $CompletionResults
   }
   else {
-    # supress default behavior (file completion) when there are no completions
+    # suppress default behavior (file completion) when there are no completions
     return $null
   }
 }

--- a/src/tool/pwsh-completion.ps1
+++ b/src/tool/pwsh-completion.ps1
@@ -191,7 +191,7 @@ $Global:_cmdliner_generic = {
     return $CompletionResults
   }
   else {
-    # supress default behavior (file completion) when there are no completions
+    # suppress default behavior (file completion) when there are no completions
     return $null
   }
 }

--- a/test/testing_cmdliner.ml
+++ b/test/testing_cmdliner.ml
@@ -46,7 +46,7 @@ let t_eval_result ok =
 let get_eval_value ?__POS__ = function
 | Ok (`Ok v) -> v
 | (Error _ | Ok `Version | Ok `Help) as v ->
-    Test.failstop ?__POS__ "Unexpected evalution: %a"
+    Test.failstop ?__POS__ "Unexpected evaluation: %a"
       (Test.T.pp (t_eval_result Test.T.any)) v
 
 let test_eval_result ?__POS__ ?env t cmd args exp =


### PR DESCRIPTION
Found via `codespell -L nd`